### PR TITLE
New tools to manage APT License Server (FlexLM)

### DIFF
--- a/Libraries/Tools/us_flexlm_tools/.gitignore
+++ b/Libraries/Tools/us_flexlm_tools/.gitignore
@@ -1,0 +1,3 @@
+/.formmaplib.fffmcat
+/.maplib.ffrmcat
+/.testcaselib.fftccat

--- a/Libraries/Tools/us_flexlm_tools/.project
+++ b/Libraries/Tools/us_flexlm_tools/.project
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>us_flexlm_tools</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>com.fnfr.svt.builders.documents.svtdocumentsbuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>com.spirent.itest.security.assets.ui.SignatureVerificationBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>com.fnfr.svt.builders.documents.svtdocumentsnature</nature>
+		<nature>com.fnfr.svt.formmapping.formmaplibrarynature</nature>
+		<nature>com.fnfr.svt.mapping.maplibrarynature</nature>
+		<nature>com.spirent.itest.security.assets.ui.SecurityNature</nature>
+	</natures>
+</projectDescription>

--- a/Libraries/Tools/us_flexlm_tools/README.txt
+++ b/Libraries/Tools/us_flexlm_tools/README.txt
@@ -1,0 +1,9 @@
+This C-shell and Tcl sctips are used to manage the APT License Server (FlexLM).
+Assumptions: license manager is installed at /usr/local/flexlm
+•	flexlm_check - This script will check various things and let you know what action to take to correct any issues
+•	flexlm_check.tcl - This script is called from flexlm_check
+•	flexlm_start - This script calls lmgrd with the necessary options
+•	flexlm_status - This script calls lmutil with the options needed to show the license server status
+•	flexlm_stop - This script calls lmutil to stop the license server
+
+Be sure to change permissions on all but the .tcl file to executable.

--- a/Libraries/Tools/us_flexlm_tools/flexlm_check
+++ b/Libraries/Tools/us_flexlm_tools/flexlm_check
@@ -1,0 +1,2 @@
+# /bin/csh
+tclsh /usr/local/flexlm/flexlm_check.tcl

--- a/Libraries/Tools/us_flexlm_tools/flexlm_check.tcl
+++ b/Libraries/Tools/us_flexlm_tools/flexlm_check.tcl
@@ -1,18 +1,40 @@
+set distro unknown
+set response [exec gcc --version]
+if {[string first "(Red Hat" $response] > -1} {
+	set distro "RedHat"
+} elseif {[string first "(Ubuntu" $response] > -1} {
+	set distro "Ubuntu"
+}
+if {$distro == "unknown"} {
+	puts "ERROR: Unknown Linux distribution. Expected RedHat or Ubuntu"
+	exit
+}
 if {![catch {exec ./lmutil lmver ./lmutil} result]} { 
 	puts [lindex [split $result \n] 1]		
 } else {
-	if {[string match "*error while loading shared libraries: libgcc_s.so.1:*" $result]} {	
-		puts "ERROR:Somthing is missing!"
-		puts "Try executing the following:"
-		puts "  sudo apt-get update"
-		puts "  sudo apt-get install -y libc6:i386 libgcc1:i386 libstdc++6:i386 libz1:i386"	
-	} elseif {[string match "*no such file or directory*" $result]} {
-		puts "ERROR:Somthing is missing!"
-		puts "Try executing the following:"
-		puts "  sudo apt-get update"
-		puts "  sudo apt-get install lsb-core"	
+	if {$distro == "Ubuntu"} {
+		if {[string match "*error while loading shared libraries: libgcc_s.so.1:*" $result]} {	
+			puts "ERROR:Something is missing!"
+			puts "Try executing the following:"
+			puts "  sudo apt-get update"
+			puts "  sudo apt-get install -y libc6:i386 libgcc1:i386 libstdc++6:i386 libz1:i386"	
+		} elseif {[string match "*no such file or directory*" $result]} {
+			puts "ERROR:Something is missing!"
+			puts "Try executing the following:"
+			puts "  sudo apt-get update"
+			puts "  sudo apt-get install lsb-core"	
+		} else {
+			puts "ERROR: $result"
+		}
 	} else {
-		puts "ERROR: $result"
+		if {[string match "*no such file or directory*" $result]} {
+			puts "ERROR:Something is missing!"
+			puts "Try executing the following:"
+			puts "  su"	
+			puts "  yum -y install redhat-lsb.i686 redhat-lsb-graphics.i686 redhat-lsb-printing.i686"	
+		} else {
+			puts "ERROR: $result"
+		}
 	}
 	exit
 }
@@ -21,15 +43,26 @@ if {![file isdirectory /usr/tmp]} {
 	puts "ERROR:Folder not found: /usr/tmp"
 	puts "spirentd (the vendor daemon) requires read/write access to this location"
 	puts "Try executing the following:"
-	puts "  sudo mkdir /usr/tmp"
-	puts "  sudo chmod 777 /usr/tmp"
+	if {$distro == "Ubuntu"} {
+		puts "  sudo mkdir /usr/tmp"
+		puts "  sudo chmod 777 /usr/tmp"
+	} else {
+		puts "  su"
+		puts "  mkdir /usr/tmp"
+		puts "  chmod 777 /usr/tmp"
+	}
 } else {
 	set perms [file attributes /usr/tmp -permissions]
 	if {![string match "???777" $perms]} {
 		puts "ERROR:Insufficient permissions for folder: /usr/tmp"
 		puts "spirentd (the vendor daemon) requires read/write access to this location"
 		puts "Try executing the following:"
-		puts "  sudo chmod 777 /usr/tmp"
+		if {$distro == "Ubuntu"} {
+			puts "  sudo chmod 777 /usr/tmp"
+		} else {
+			puts "  su"
+			puts "  chmod 777 /usr/tmp"
+		}
 	}
 }
 
@@ -38,7 +71,12 @@ if {[catch {exec ./lmutil lmhostid -ptype VM} result]} {
 		puts "VM UUID file not readable:"
 		puts "You will not be able to get the UUID for a license until the file permissions are corrected."
 		puts "Try executing the following:"
-		puts "  sudo chmod 666 /sys/devices/virtual/dmi/id/product_uuid"
+		if {$distro == "Ubuntu"} {
+			puts "  sudo chmod 666 /sys/devices/virtual/dmi/id/product_uuid"
+		} else {
+			puts "  su"
+			puts "  chmod 666 /sys/devices/virtual/dmi/id/product_uuid"
+		}
 	} else {
 		puts "ERROR:Could not get UUID"
 		puts "You will not be able to get the UUID for a license until the problem is corrected."

--- a/Libraries/Tools/us_flexlm_tools/flexlm_check.tcl
+++ b/Libraries/Tools/us_flexlm_tools/flexlm_check.tcl
@@ -1,0 +1,54 @@
+if {![catch {exec ./lmutil lmver ./lmutil} result]} { 
+	puts [lindex [split $result \n] 1]		
+} else {
+	if {[string match "*error while loading shared libraries: libgcc_s.so.1:*" $result]} {	
+		puts "ERROR:Somthing is missing!"
+		puts "Try executing the following:"
+		puts "  sudo apt-get update"
+		puts "  sudo apt-get install -y libc6:i386 libgcc1:i386 libstdc++6:i386 libz1:i386"	
+	} elseif {[string match "*no such file or directory*" $result]} {
+		puts "ERROR:Somthing is missing!"
+		puts "Try executing the following:"
+		puts "  sudo apt-get update"
+		puts "  sudo apt-get install lsb-core"	
+	} else {
+		puts "ERROR: $result"
+	}
+	exit
+}
+
+if {![file isdirectory /usr/tmp]} {
+	puts "ERROR:Folder not found: /usr/tmp"
+	puts "spirentd (the vendor daemon) requires read/write access to this location"
+	puts "Try executing the following:"
+	puts "  sudo mkdir /usr/tmp"
+	puts "  sudo chmod 777 /usr/tmp"
+} else {
+	set perms [file attributes /usr/tmp -permissions]
+	if {![string match "???777" $perms]} {
+		puts "ERROR:Insufficient permissions for folder: /usr/tmp"
+		puts "spirentd (the vendor daemon) requires read/write access to this location"
+		puts "Try executing the following:"
+		puts "  sudo chmod 777 /usr/tmp"
+	}
+}
+
+if {[catch {exec ./lmutil lmhostid -ptype VM} result]} { 
+	if {![file readable /sys/devices/virtual/dmi/id/product_uuid]} {
+		puts "VM UUID file not readable:"
+		puts "You will not be able to get the UUID for a license until the file permissions are corrected."
+		puts "Try executing the following:"
+		puts "  sudo chmod 666 /sys/devices/virtual/dmi/id/product_uuid"
+	} else {
+		puts "ERROR:Could not get UUID"
+		puts "You will not be able to get the UUID for a license until the problem is corrected."
+	}
+} else {
+	set uuid [string map {\" ""} [lindex [split $result =] 1]]	
+	puts "VM_UUID=$uuid"
+}
+
+#if {![catch {exec ./lmutil lmhostid} result]} { 
+#	set temp [string map {\" ""} $result]	
+#	puts "Host ID=[lindex $temp end]"
+#}

--- a/Libraries/Tools/us_flexlm_tools/flexlm_start
+++ b/Libraries/Tools/us_flexlm_tools/flexlm_start
@@ -1,0 +1,4 @@
+# /bin/csh
+/usr/local/flexlm/lmgrd -c /usr/local/flexlm/license -l /tmp/flexlm.log
+sleep 2
+cat /tmp/flexlm.log

--- a/Libraries/Tools/us_flexlm_tools/flexlm_status
+++ b/Libraries/Tools/us_flexlm_tools/flexlm_status
@@ -1,0 +1,3 @@
+# /bin/csh
+/usr/local/flexlm/lmutil lmstat -a > /tmp/lmstat.txt
+cat /tmp/lmstat.txt

--- a/Libraries/Tools/us_flexlm_tools/flexlm_stop
+++ b/Libraries/Tools/us_flexlm_tools/flexlm_stop
@@ -1,0 +1,2 @@
+# /bin/csh
+/usr/local/flexlm/lmutil lmdown


### PR DESCRIPTION
These are scripts to help manage the APT License manager. They assume that the license manager is installed at /usr/local/flexlm. It would be nice if they could be included in the new installer for Linux.