### PR TITLE
Update flexlm_status

### DIFF
--- a/Libraries/Tools/Community/us_flexlm_tools/flexlm_status
+++ b/Libraries/Tools/Community/us_flexlm_tools/flexlm_status
@@ -1,3 +1,3 @@
-# /bin/csh
-/usr/local/flexlm/lmutil lmstat -a > /tmp/lmstat.txt
+#!/bin/sh
+/usr/local/apt-flexlm/lmutil lmstat -c /usr/local/apt-flexlm/licenses -a > /tmp/lmstat.txt
 cat /tmp/lmstat.txt


### PR DESCRIPTION
Switch from csh to sh.
Changed install destination folder from flexlm to apt-flexlm.
Changed license folder from license to licenses to be more consistent with latest APT installer.