### PR TITLE
Now supports procedure library documentation.

### DIFF
--- a/Libraries/DUTs/Community/di_dslam_huawei/README.md
+++ b/Libraries/DUTs/Community/di_dslam_huawei/README.md
@@ -1,7 +1,11 @@
-# project://di_dslam_huawei
-1 QuickCall Library in project://di_dslam_huawei:
-## Huawei CLI Base (project://di_dslam_huawei/session_profiles/huawei_base.fftc)
+Project: Huawei DSLAM
+Description: QuickCalls and response maps useful for building system tests automating the Huawei DSLAM
+Category: library
+Class: Community
 
+1 QuickCall Library in project://di_dslam_huawei
+## Library: project://di_dslam_huawei/session_profiles/huawei_base.fftc
+## Headline: Huawei CLI Base
 ### login
 Login with the credentials for the device. Because these credentials may be different for each device, this QuickCall should be replicated for each device QuickCall library.
 Also, enter the configuration mode and trun off alarm and event output. 

--- a/Libraries/DUTs/Community/di_dslam_huawei/documentation/README.txt
+++ b/Libraries/DUTs/Community/di_dslam_huawei/documentation/README.txt
@@ -1,2 +1,0 @@
-This folder is for any documentation related to this project.
-Reference Guides, hardware specifications, examples, etc.

--- a/Libraries/DUTs/Community/di_dslam_huawei/documentation/index.html
+++ b/Libraries/DUTs/Community/di_dslam_huawei/documentation/index.html
@@ -10,10 +10,16 @@ H1,H2{padding-left:15px}
 .header2Text{font-size:20px; color:darkblue; font-weight:bold; font-family:arial ;text-align:left; padding-left:5px}
 .header3Text{font-size:18px; color:darkblue; font-weight:bold; font-family:arial ;text-align:left; padding-left:10px}
 </style>
-<BR><DIV class='headerText'>project://di_dslam_huawei</DIV>
-<BR><DIV class='header2Text'>1 QuickCall Library in project://di_dslam_huawei:</DIV>
-<BR><DIV class='header2Text'>Huawei CLI Base (project://di_dslam_huawei/session_profiles/huawei_base.fftc)</DIV><BR>
-<DIV class='qcNotesText'></DIV>
+<DIV class='normalText'>Project: Huawei DSLAM</DIV>
+<DIV class='normalText'>Description: QuickCalls and response maps useful for building system tests automating the Huawei DSLAM</DIV>
+<DIV class='normalText'>Category: library</DIV>
+<DIV class='normalText'>Class: Community</DIV>
+<DIV style='margin-left:30px; ' class='normalText'><BR></DIV>
+<BR><DIV class='normalText'>1 QuickCall Library in project://di_dslam_huawei</DIV>
+<br>
+<DIV class='header2Text'>Library: project://di_dslam_huawei/session_profiles/huawei_base.fftc</DIV>
+<DIV class='header3Text'>Headline: Huawei CLI Base</DIV>
+<br>
 <DIV style='margin-left:30px; font-size:18px;color:darkgreen;font-weight:bold; font-family:courier'>login</DIV>
 <DIV class='procText'>Login with the credentials for the device. Because these credentials may be different for each device, this QuickCall should be replicated for each device QuickCall library.
 Also, enter the configuration mode and trun off alarm and event output. </DIV><BR>

--- a/Libraries/DUTs/Community/di_dslam_huawei/documentation/readme.txt
+++ b/Libraries/DUTs/Community/di_dslam_huawei/documentation/readme.txt
@@ -1,0 +1,4 @@
+Project: Huawei DSLAM
+Description: QuickCalls and response maps useful for building system tests automating the Huawei DSLAM
+Category: library
+Class: Community

--- a/Libraries/DUTs/Community/di_dslam_umc/README.md
+++ b/Libraries/DUTs/Community/di_dslam_umc/README.md
@@ -1,7 +1,12 @@
-# project://di_dslam_umc
-1 QuickCall Library in project://di_dslam_umc:
-## Adtran QuickCall Library (project://di_dslam_umc/session_profiles/umc_1000.fftc)
-Support for:
+Project: UMC DSLAM
+Description: QuickCalls and response maps useful for building system tests automating the UMC DSLAM
+Category: library
+Class: Community
+
+1 QuickCall Library in project://di_dslam_umc
+## Library: project://di_dslam_umc/session_profiles/umc_1000.fftc
+## Headline: Adtran QuickCall Library
+Description: Support for:
 1100F
 1200F
 ### login

--- a/Libraries/DUTs/Community/di_dslam_umc/documentation/README.txt
+++ b/Libraries/DUTs/Community/di_dslam_umc/documentation/README.txt
@@ -1,2 +1,0 @@
-This folder is for any documentation related to this project.
-Reference Guides, hardware specifications, examples, etc.

--- a/Libraries/DUTs/Community/di_dslam_umc/documentation/index.html
+++ b/Libraries/DUTs/Community/di_dslam_umc/documentation/index.html
@@ -10,12 +10,19 @@ H1,H2{padding-left:15px}
 .header2Text{font-size:20px; color:darkblue; font-weight:bold; font-family:arial ;text-align:left; padding-left:5px}
 .header3Text{font-size:18px; color:darkblue; font-weight:bold; font-family:arial ;text-align:left; padding-left:10px}
 </style>
-<BR><DIV class='headerText'>project://di_dslam_umc</DIV>
-<BR><DIV class='header2Text'>1 QuickCall Library in project://di_dslam_umc:</DIV>
-<BR><DIV class='header2Text'>Adtran QuickCall Library (project://di_dslam_umc/session_profiles/umc_1000.fftc)</DIV><BR>
-<DIV class='qcNotesText'>Support for:
+<DIV class='normalText'>Project: UMC DSLAM</DIV>
+<DIV class='normalText'>Description: QuickCalls and response maps useful for building system tests automating the UMC DSLAM</DIV>
+<DIV class='normalText'>Category: library</DIV>
+<DIV class='normalText'>Class: Community</DIV>
+<DIV style='margin-left:30px; ' class='normalText'><BR></DIV>
+<BR><DIV class='normalText'>1 QuickCall Library in project://di_dslam_umc</DIV>
+<br>
+<DIV class='header2Text'>Library: project://di_dslam_umc/session_profiles/umc_1000.fftc</DIV>
+<DIV class='header3Text'>Headline: Adtran QuickCall Library</DIV>
+<DIV class='header3Text'>Description: Support for:
 1100F
 1200F</DIV>
+<br>
 <DIV style='margin-left:30px; font-size:18px;color:darkgreen;font-weight:bold; font-family:courier'>login</DIV>
 <DIV class='procText'></DIV><BR>
 <DIV style='margin-left:30px; font-size:18px;color:darkgreen;font-weight:bold; font-family:courier'>getFootprint</DIV>

--- a/Libraries/DUTs/Community/di_dslam_umc/documentation/readme.txt
+++ b/Libraries/DUTs/Community/di_dslam_umc/documentation/readme.txt
@@ -1,0 +1,4 @@
+Project: UMC DSLAM
+Description: QuickCalls and response maps useful for building system tests automating the UMC DSLAM
+Category: library
+Class: Community

--- a/Libraries/Test.Equipment/TestedBySpirent/di_STC/README.md
+++ b/Libraries/Test.Equipment/TestedBySpirent/di_STC/README.md
@@ -1,10 +1,14 @@
-# Spirent Test Center Device Project
-Provides basic traffic quickcalls for the STC Tcl API session type and response maps for result and statistics views. Tested with STC FW version 4.75. 
+Project: Spirent Test Center Device
+Description: Provides basic traffic quickcalls for the STC Tcl API session type and response maps for result and statistics views. Tested with STC FW version 4.75. 
+Category: library
+Class: Tested by Spirent
+
 <b>Tags:</b> Test Equipment, Traffic Generator
 
-1 QuickCall Library in project://di_STC:
-## STC Tcl API Quick Call Library (project://di_STC/session_profiles/STC_TclAPI_QCLib.fftc)
-STC Tcl API Quickcalls
+1 QuickCall Library in project://di_STC
+## Library: project://di_STC/session_profiles/STC_TclAPI_QCLib.fftc
+## Headline: STC Tcl API Quick Call Library
+Description: STC Tcl API Quickcalls
 ### StartArp
 Starts ARP/ND on all devices in config. Returns status in a JSON block.
 Returns block 

--- a/Libraries/Test.Equipment/TestedBySpirent/di_STC/documentation/index.html
+++ b/Libraries/Test.Equipment/TestedBySpirent/di_STC/documentation/index.html
@@ -10,13 +10,19 @@ H1,H2{padding-left:15px}
 .header2Text{font-size:20px; color:darkblue; font-weight:bold; font-family:arial ;text-align:left; padding-left:5px}
 .header3Text{font-size:18px; color:darkblue; font-weight:bold; font-family:arial ;text-align:left; padding-left:10px}
 </style>
-<BR><DIV class='headerText'>Spirent Test Center Device Project</DIV>
-<DIV style='margin-left:30px; ' class='normalText'>Provides basic traffic quickcalls for the STC Tcl API session type and response maps for result and statistics views. Tested with STC FW version 4.75. </DIV>
-<DIV style='margin-left:30px; ' class='normalText'><b>Tags:</b> Test Equipment, Traffic Generator</DIV>
+<DIV class='normalText'>Project: Spirent Test Center Device</DIV>
+<DIV class='normalText'>Description: Provides basic traffic quickcalls for the STC Tcl API session type and response maps for result and statistics views. Tested with STC FW version 4.75. </DIV>
+<DIV class='normalText'>Category: library</DIV>
+<DIV class='normalText'>Class: Tested by Spirent</DIV>
 <DIV style='margin-left:30px; ' class='normalText'><BR></DIV>
-<BR><DIV class='header2Text'>1 QuickCall Library in project://di_STC:</DIV>
-<BR><DIV class='header2Text'>STC Tcl API Quick Call Library (project://di_STC/session_profiles/STC_TclAPI_QCLib.fftc)</DIV><BR>
-<DIV class='qcNotesText'>STC Tcl API Quickcalls</DIV>
+<DIV class='normalText'><b>Tags:</b> Test Equipment, Traffic Generator</DIV>
+<DIV style='margin-left:30px; ' class='normalText'><BR></DIV>
+<BR><DIV class='normalText'>1 QuickCall Library in project://di_STC</DIV>
+<br>
+<DIV class='header2Text'>Library: project://di_STC/session_profiles/STC_TclAPI_QCLib.fftc</DIV>
+<DIV class='header3Text'>Headline: STC Tcl API Quick Call Library</DIV>
+<DIV class='header3Text'>Description: STC Tcl API Quickcalls</DIV>
+<br>
 <DIV style='margin-left:30px; font-size:18px;color:darkgreen;font-weight:bold; font-family:courier'>StartArp</DIV>
 <DIV class='procText'>Starts ARP/ND on all devices in config. Returns status in a JSON block.
 Returns block 

--- a/Libraries/Test.Equipment/TestedBySpirent/di_STC/documentation/readme.txt
+++ b/Libraries/Test.Equipment/TestedBySpirent/di_STC/documentation/readme.txt
@@ -1,3 +1,6 @@
-Spirent Test Center Device Project
-Provides basic traffic quickcalls for the STC Tcl API session type and response maps for result and statistics views. Tested with STC FW version 4.75. 
+Project: Spirent Test Center Device
+Description: Provides basic traffic quickcalls for the STC Tcl API session type and response maps for result and statistics views. Tested with STC FW version 4.75. 
+Category: library
+Class: Tested by Spirent
+
 <b>Tags:</b> Test Equipment, Traffic Generator

--- a/Libraries/Tools/Community/ui_documentation/README.md
+++ b/Libraries/Tools/Community/ui_documentation/README.md
@@ -1,1 +1,62 @@
-# project://ui_documentation
+Project: Documentation Generator
+Description: Generate project documentation, for Git repository, from QuickCall and Procedure libraries. 
+Category: automation
+Class: Community
+
+1 Procedure Library in project://ui_documentation
+## Library: project://ui_documentation/test_cases/documentation.fftc
+## Headline: Documentation Generator
+Description: This test case will generate documentation for QuickCall and Procedure libraries. The Headline and Description should be completed for General Information and all procedures. Procedure arguments should also have a description.
+
+Parameters:
+changeDate - Only projects which have changed since that date will have the documentation regenerated. Only .fftc, .ffrm and readme.txt files are checked for change.
+
+uriDocumentationList - If specified and file exists, only the projects listed in the file will be updated, regardless of the change state.
+
+includeResponseMaps - If true, inlude a list of response maps along with heading and description.
+
+### getProjectList
+Return a list of project URI's within the current workspace
+### getUriList
+Return a list of test case URI's within a given project URI
+
+Argument | Description
+------------ | -------------
+uriPath | URI of project
+### getLibList
+Get list of QuickCall Libraries and Procedure Libraries from given list of test case URI's
+
+Argument | Description
+------------ | -------------
+uriList | List of file URI's
+### createFiles
+Create HTML and MD files
+
+Argument | Description
+------------ | -------------
+uriPath | URI to project
+### writeLibrariesFound
+Build a separate list of QuickCall and Procedure libraries
+
+Argument | Description
+------------ | -------------
+uriPath | URI to project
+### writeInfo
+Append to HTML and MD: procedure names, descriptions and arguments
+
+Argument | Description
+------------ | -------------
+uriPath | URI to project
+uriList | List of library URI's 
+### writeRMInfo
+Append to HTML and MD: procedure names, descriptions and arguments
+
+Argument | Description
+------------ | -------------
+uriPath | URI to project
+uriList | List of response map URI's 
+### fileChanged
+
+Argument | Description
+------------ | -------------
+uri | URI of file to check

--- a/Libraries/Tools/Community/ui_documentation/README.md
+++ b/Libraries/Tools/Community/ui_documentation/README.md
@@ -1,6 +1,6 @@
 Project: Documentation Generator
 Description: Generate project documentation, for Git repository, from QuickCall and Procedure libraries. 
-Category: automation
+Category: library
 Class: Community
 
 1 Procedure Library in project://ui_documentation

--- a/Libraries/Tools/Community/ui_documentation/documentation/index.html
+++ b/Libraries/Tools/Community/ui_documentation/documentation/index.html
@@ -12,7 +12,7 @@ H1,H2{padding-left:15px}
 </style>
 <DIV class='normalText'>Project: Documentation Generator</DIV>
 <DIV class='normalText'>Description: Generate project documentation, for Git repository, from QuickCall and Procedure libraries. </DIV>
-<DIV class='normalText'>Category: automation</DIV>
+<DIV class='normalText'>Category: library</DIV>
 <DIV class='normalText'>Class: Community</DIV>
 <DIV style='margin-left:30px; ' class='normalText'><BR></DIV>
 <BR><DIV class='normalText'>1 Procedure Library in project://ui_documentation</DIV>

--- a/Libraries/Tools/Community/ui_documentation/documentation/index.html
+++ b/Libraries/Tools/Community/ui_documentation/documentation/index.html
@@ -10,4 +10,94 @@ H1,H2{padding-left:15px}
 .header2Text{font-size:20px; color:darkblue; font-weight:bold; font-family:arial ;text-align:left; padding-left:5px}
 .header3Text{font-size:18px; color:darkblue; font-weight:bold; font-family:arial ;text-align:left; padding-left:10px}
 </style>
-<BR><DIV class='headerText'>project://ui_documentation</DIV>
+<DIV class='normalText'>Project: Documentation Generator</DIV>
+<DIV class='normalText'>Description: Generate project documentation, for Git repository, from QuickCall and Procedure libraries. </DIV>
+<DIV class='normalText'>Category: automation</DIV>
+<DIV class='normalText'>Class: Community</DIV>
+<DIV style='margin-left:30px; ' class='normalText'><BR></DIV>
+<BR><DIV class='normalText'>1 Procedure Library in project://ui_documentation</DIV>
+<br>
+<DIV class='header2Text'>Library: project://ui_documentation/test_cases/documentation.fftc</DIV>
+<DIV class='header3Text'>Headline: Documentation Generator</DIV>
+<DIV class='header3Text'>Description: This test case will generate documentation for QuickCall and Procedure libraries. The Headline and Description should be completed for General Information and all procedures. Procedure arguments should also have a description.
+
+Parameters:
+changeDate - Only projects which have changed since that date will have the documentation regenerated. Only .fftc, .ffrm and readme.txt files are checked for change.
+
+uriDocumentationList - If specified and file exists, only the projects listed in the file will be updated, regardless of the change state.
+
+includeResponseMaps - If true, inlude a list of response maps along with heading and description.
+</DIV>
+<br>
+<DIV style='margin-left:30px; font-size:18px;color:darkgreen;font-weight:bold; font-family:courier'>getProjectList</DIV>
+<DIV class='procText'>Return a list of project URI's within the current workspace</DIV><BR>
+<DIV style='margin-left:30px; font-size:18px;color:darkgreen;font-weight:bold; font-family:courier'>getUriList</DIV>
+<DIV class='procText'>Return a list of test case URI's within a given project URI</DIV><BR>
+<DIV class='normalText'><TABLE style='margin-left:30px; width=600px'>
+<TR><TH style='width:200px; padding:5px;color:darkblue;' class='normalText'>Argument</TH>
+<TH style='width:400px; padding:5px;color:darkblue;' class='normalText'>Description</TH></TR>
+<TR><TD style='width:200px; padding:5px;color:darkblue' class='normalText'>uriPath</TD>
+<TD style='width:400px; padding:5px;color:darkblue' class='normalText'>URI of project </TD>
+</TR>
+</TABLE></DIV><br>
+<DIV style='margin-left:30px; font-size:18px;color:darkgreen;font-weight:bold; font-family:courier'>getLibList</DIV>
+<DIV class='procText'>Get list of QuickCall Libraries and Procedure Libraries from given list of test case URI's</DIV><BR>
+<DIV class='normalText'><TABLE style='margin-left:30px; width=600px'>
+<TR><TH style='width:200px; padding:5px;color:darkblue;' class='normalText'>Argument</TH>
+<TH style='width:400px; padding:5px;color:darkblue;' class='normalText'>Description</TH></TR>
+<TR><TD style='width:200px; padding:5px;color:darkblue' class='normalText'>uriList</TD>
+<TD style='width:400px; padding:5px;color:darkblue' class='normalText'>List of file URI's </TD>
+</TR>
+</TABLE></DIV><br>
+<DIV style='margin-left:30px; font-size:18px;color:darkgreen;font-weight:bold; font-family:courier'>createFiles</DIV>
+<DIV class='procText'>Create HTML and MD files</DIV><BR>
+<DIV class='normalText'><TABLE style='margin-left:30px; width=600px'>
+<TR><TH style='width:200px; padding:5px;color:darkblue;' class='normalText'>Argument</TH>
+<TH style='width:400px; padding:5px;color:darkblue;' class='normalText'>Description</TH></TR>
+<TR><TD style='width:200px; padding:5px;color:darkblue' class='normalText'>uriPath</TD>
+<TD style='width:400px; padding:5px;color:darkblue' class='normalText'>URI to project </TD>
+</TR>
+</TABLE></DIV><br>
+<DIV style='margin-left:30px; font-size:18px;color:darkgreen;font-weight:bold; font-family:courier'>writeLibrariesFound</DIV>
+<DIV class='procText'>Build a separate list of QuickCall and Procedure libraries</DIV><BR>
+<DIV class='normalText'><TABLE style='margin-left:30px; width=600px'>
+<TR><TH style='width:200px; padding:5px;color:darkblue;' class='normalText'>Argument</TH>
+<TH style='width:400px; padding:5px;color:darkblue;' class='normalText'>Description</TH></TR>
+<TR><TD style='width:200px; padding:5px;color:darkblue' class='normalText'>uriPath</TD>
+<TD style='width:400px; padding:5px;color:darkblue' class='normalText'>URI to project </TD>
+</TR>
+</TABLE></DIV><br>
+<DIV style='margin-left:30px; font-size:18px;color:darkgreen;font-weight:bold; font-family:courier'>writeInfo</DIV>
+<DIV class='procText'>Append to HTML and MD: procedure names, descriptions and arguments</DIV><BR>
+<DIV class='normalText'><TABLE style='margin-left:30px; width=600px'>
+<TR><TH style='width:200px; padding:5px;color:darkblue;' class='normalText'>Argument</TH>
+<TH style='width:400px; padding:5px;color:darkblue;' class='normalText'>Description</TH></TR>
+<TR><TD style='width:200px; padding:5px;color:darkblue' class='normalText'>uriPath</TD>
+<TD style='width:400px; padding:5px;color:darkblue' class='normalText'>URI to project </TD>
+</TR>
+<TR><TD style='width:200px; padding:5px;color:darkblue' class='normalText'>uriList</TD>
+<TD style='width:400px; padding:5px;color:darkblue' class='normalText'>List of library URI's  </TD>
+</TR>
+</TABLE></DIV><br>
+<DIV style='margin-left:30px; font-size:18px;color:darkgreen;font-weight:bold; font-family:courier'>writeRMInfo</DIV>
+<DIV class='procText'>Append to HTML and MD: procedure names, descriptions and arguments</DIV><BR>
+<DIV class='normalText'><TABLE style='margin-left:30px; width=600px'>
+<TR><TH style='width:200px; padding:5px;color:darkblue;' class='normalText'>Argument</TH>
+<TH style='width:400px; padding:5px;color:darkblue;' class='normalText'>Description</TH></TR>
+<TR><TD style='width:200px; padding:5px;color:darkblue' class='normalText'>uriPath</TD>
+<TD style='width:400px; padding:5px;color:darkblue' class='normalText'>URI to project </TD>
+</TR>
+<TR><TD style='width:200px; padding:5px;color:darkblue' class='normalText'>uriList</TD>
+<TD style='width:400px; padding:5px;color:darkblue' class='normalText'>List of response map URI's  </TD>
+</TR>
+</TABLE></DIV><br>
+<DIV style='margin-left:30px; font-size:18px;color:darkgreen;font-weight:bold; font-family:courier'>fileChanged</DIV>
+<DIV class='procText'></DIV><BR>
+<DIV class='normalText'><TABLE style='margin-left:30px; width=600px'>
+<TR><TH style='width:200px; padding:5px;color:darkblue;' class='normalText'>Argument</TH>
+<TH style='width:400px; padding:5px;color:darkblue;' class='normalText'>Description</TH></TR>
+<TR><TD style='width:200px; padding:5px;color:darkblue' class='normalText'>uri</TD>
+<TD style='width:400px; padding:5px;color:darkblue' class='normalText'>URI of file to check </TD>
+</TR>
+</TABLE></DIV><br>
+<br>

--- a/Libraries/Tools/Community/ui_documentation/documentation/readme.txt
+++ b/Libraries/Tools/Community/ui_documentation/documentation/readme.txt
@@ -1,4 +1,4 @@
 Project: Documentation Generator
 Description: Generate project documentation, for Git repository, from QuickCall and Procedure libraries. 
-Category: automation
+Category: library
 Class: Community

--- a/Libraries/Tools/Community/ui_documentation/documentation/readme.txt
+++ b/Libraries/Tools/Community/ui_documentation/documentation/readme.txt
@@ -1,0 +1,4 @@
+Project: Documentation Generator
+Description: Generate project documentation, for Git repository, from QuickCall and Procedure libraries. 
+Category: automation
+Class: Community

--- a/Libraries/Tools/Community/ui_documentation/documentation/readme_template.txt
+++ b/Libraries/Tools/Community/ui_documentation/documentation/readme_template.txt
@@ -1,0 +1,4 @@
+Project: <name>
+Description: <Some wording about what the project does or is used for>
+Category: <"library", "automation", or "framework">
+Class: <"Community", "Tested by Spirent", "Reference">

--- a/Libraries/Tools/Community/ui_documentation/response_maps/dateManipulation.ffrm
+++ b/Libraries/Tools/Community/ui_documentation/response_maps/dateManipulation.ffrm
@@ -1,5 +1,7 @@
 <?xml version="1.0"?>
-<ResponseMap version="5.2.0.95bb698">
+<ResponseMap version="7.0.1.201802131446">
+    <notes>Use pattern mapping to create queries: year, month, day, time</notes>
+    <headline>Extract info from timestamp</headline>
     <sampleDictionary>
         <item name="sample1">
             <action actionType="eval">

--- a/Libraries/Tools/Community/ui_documentation/test_cases/documentation.fftc
+++ b/Libraries/Tools/Community/ui_documentation/test_cases/documentation.fftc
@@ -1,10 +1,25 @@
 <?xml version="1.0"?>
 <testCase version="7.0.1.201802131446">
+    <general>
+        <documentation>Documentation Generator</documentation>
+        <notes>This test case will generate documentation for QuickCall and Procedure libraries. The Headline and Description should be completed for General Information and all procedures. Procedure arguments should also have a description.
+
+Parameters:
+changeDate - Only projects which have changed since that date will have the documentation regenerated. Only .fftc, .ffrm and readme.txt files are checked for change.
+
+uriDocumentationList - If specified and file exists, only the projects listed in the file will be updated, regardless of the change state.
+
+includeResponseMaps - If true, inlude a list of response maps along with heading and description.
+</notes>
+        <isProcedureLibrary>true</isProcedureLibrary>
+    </general>
     <execution estimatedExecutionTime="-673">
         <parameters version="7.0.1.201802131446">
             <parameters escape="true">
                 <parameters xmlns:pt="http://www.fnfr.com/schemas/parameterTree">
-                    <changedDate>3/15/16</changedDate>
+                    <changedDate pt:description="mm/dd/yyyy">4/25/2018</changedDate>
+                    <uriDocumentationList pt:description="URI to file containing a list of projects to document">project://my_project/iTest_documentation_list.txt</uriDocumentationList>
+                    <includeResponseMaps pt:datatype="BOOLEAN" pt:description="Inlude response maps heading and description">false</includeResponseMaps>
                 </parameters>
             </parameters>
         </parameters>
@@ -12,220 +27,360 @@
     <procedures>
         <item name="main">
             <steps>
-                <item guid="2ca91a34-5457-46d7-b91f-c115db2d1312" action="comment">
+                <item guid="d62d3647-8555-4656-9ccf-815ce9bb9de5" action="eval">
                     <command>
-                        <body>set changed date tolerance</body>
+                        <body>gset QC_LIB_URI_LIST {}</body>
+                    </command>
+                    <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                    <useFieldsInCommand>false</useFieldsInCommand>
+                </item>
+                <item guid="69b3aebc-c9f3-46c3-a53c-03a9a69f74e5" action="eval">
+                    <command>
+                        <body>gset PROC_LIB_URI_LIST {}</body>
+                    </command>
+                    <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                    <useFieldsInCommand>false</useFieldsInCommand>
+                </item>
+                <item guid="d6b7bd1b-70ae-46bc-aa76-fae1d16e863b" action="eval">
+                    <command>
+                        <body>gset RM_LIB_URI_LIST {}</body>
+                    </command>
+                    <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                    <useFieldsInCommand>false</useFieldsInCommand>
+                </item>
+                <item guid="cc0232cd-70a5-4e82-90ea-4580630fca38" action="eval">
+                    <command>
+                        <body>set uri [param uriDocumentationList &quot;&quot;]</body>
+                    </command>
+                    <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                    <useFieldsInCommand>false</useFieldsInCommand>
+                </item>
+                <item guid="8be2e26a-1d54-4356-99f3-98dfef713334" action="if">
+                    <command>
+                        <body>![file exists $uri]</body>
                     </command>
                     <nestedSteps>
-                        <item guid="d9a3b15b-772c-4913-9715-b68233042d25" action="open" session="tcl1">
-                            <command>
-                                <body>application:com.fnfr.svt.applications.tclsh</body>
-                            </command>
-                            <applicationProperties type="com.fnfr.svt.documents.OpenStepPropertyGroup">
-                                <stepProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
-                                <sessionProperties type="com.fnfr.svt.applications.tclsh.TclshSessionProperties"/>
-                                <sessionClass type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
-                                <sessionVersion type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
-                            </applicationProperties>
+                        <item guid="a8dadaab-66ad-4b8c-a653-23ef402d101f" action="then">
+                            <nestedSteps>
+                                <item guid="86d87ac0-d2c0-46de-8b26-4b937117983d" action="comment">
+                                    <postProcessing>
+                                        <analysisRules>
+                                            <item>
+                                                <extractorInfo extractorType="none">
+                                                    <extractorProperties type="com.fnfr.svt.documents.EmptyExtractorPropertyGroup"/>
+                                                </extractorInfo>
+                                                <processorInfo ruleType="message">
+                                                    <ruleProperties type="com.fnfr.svt.execution.builtin.processors.MessageProcessorPropertyGroup" severity="Warning">
+                                                        <message>Only updating projects that have changed since [param changedDate] </message>
+                                                    </ruleProperties>
+                                                </processorInfo>
+                                            </item>
+                                            <item>
+                                                <extractorInfo extractorType="none">
+                                                    <extractorProperties type="com.fnfr.svt.documents.EmptyExtractorPropertyGroup"/>
+                                                </extractorInfo>
+                                                <processorInfo ruleType="message">
+                                                    <ruleProperties type="com.fnfr.svt.execution.builtin.processors.MessageProcessorPropertyGroup" severity="Warning">
+                                                        <message>If you wish to change this date, edit changedDate parameter. </message>
+                                                    </ruleProperties>
+                                                </processorInfo>
+                                            </item>
+                                        </analysisRules>
+                                    </postProcessing>
+                                    <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                                    <useFieldsInCommand>false</useFieldsInCommand>
+                                </item>
+                                <item guid="1bbbd188-3e30-4c1a-8a02-08c20b959592" action="eval">
+                                    <command>
+                                        <body>gset CHANGE_BY_DATE 1</body>
+                                    </command>
+                                    <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                                    <useFieldsInCommand>false</useFieldsInCommand>
+                                </item>
+                            </nestedSteps>
+                            <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
                             <useFieldsInCommand>false</useFieldsInCommand>
                         </item>
-                        <item guid="b15b4c77-58b4-41ea-9a0c-053e81cd1aad" action="command" session="tcl1">
-                            <command>
-                                <body>clock scan [param changedDate]</body>
-                            </command>
-                            <postProcessing>
-                                <analysisRules>
-                                    <item>
-                                        <extractorInfo extractorType="regex">
-                                            <extractorProperties type="com.fnfr.svt.mapping.regex.extractors.RegexExtractorPropertyGroup" useLineMode="true">
-                                                <regex>^(\\d+)$</regex>
-                                            </extractorProperties>
-                                        </extractorInfo>
-                                        <processorInfo ruleType="store">
-                                            <ruleProperties type="com.fnfr.svt.execution.builtin.processors.StoreProcessorPropertyGroup">
-                                                <storageLocation>changeSeconds</storageLocation>
-                                            </ruleProperties>
-                                        </processorInfo>
-                                    </item>
-                                </analysisRules>
-                            </postProcessing>
+                        <item guid="f06ffd47-36a8-4ced-a56e-83f08f4494a3" action="else">
+                            <nestedSteps>
+                                <item guid="9c8280f2-0188-494e-bee9-5fd9dc4bba58" action="comment">
+                                    <postProcessing>
+                                        <analysisRules>
+                                            <item>
+                                                <extractorInfo extractorType="none">
+                                                    <extractorProperties type="com.fnfr.svt.documents.EmptyExtractorPropertyGroup"/>
+                                                </extractorInfo>
+                                                <processorInfo ruleType="message">
+                                                    <ruleProperties type="com.fnfr.svt.execution.builtin.processors.MessageProcessorPropertyGroup" severity="Warning">
+                                                        <message>Only updating projects that are listed in file: [param uriDocumentationList]</message>
+                                                    </ruleProperties>
+                                                </processorInfo>
+                                            </item>
+                                            <item>
+                                                <extractorInfo extractorType="none">
+                                                    <extractorProperties type="com.fnfr.svt.documents.EmptyExtractorPropertyGroup"/>
+                                                </extractorInfo>
+                                                <processorInfo ruleType="message">
+                                                    <ruleProperties type="com.fnfr.svt.execution.builtin.processors.MessageProcessorPropertyGroup" severity="Warning">
+                                                        <message>If you wish to change the location, edit uriDocumentationList parameter. </message>
+                                                    </ruleProperties>
+                                                </processorInfo>
+                                            </item>
+                                        </analysisRules>
+                                    </postProcessing>
+                                    <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                                    <useFieldsInCommand>false</useFieldsInCommand>
+                                </item>
+                                <item guid="cfcf35b8-b8a4-4f6d-abd3-a68196a8810d" action="eval">
+                                    <command>
+                                        <body>gset CHANGE_BY_DATE 0</body>
+                                    </command>
+                                    <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                                    <useFieldsInCommand>false</useFieldsInCommand>
+                                </item>
+                            </nestedSteps>
                             <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                            <useFieldsInCommand>false</useFieldsInCommand>
                         </item>
                     </nestedSteps>
                     <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
                     <useFieldsInCommand>false</useFieldsInCommand>
                 </item>
-                <item guid="5201ff0b-1010-456f-852f-e6501b7add7c" action="comment">
+                <item guid="f3da42e4-539c-477c-bce0-ab33124913b9" action="call">
                     <command>
-                        <body>get all projects in workspace</body>
+                        <body>getProjectList</body>
                     </command>
-                    <nestedSteps>
-                        <item guid="2d6e4929-bce1-4ac6-b2c0-027dab4e6a90" action="eval">
-                            <command>
-                                <body>set wsp [ info workspacePath ]</body>
-                            </command>
-                            <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
-                            <useFieldsInCommand>false</useFieldsInCommand>
-                        </item>
-                        <item guid="7b305070-dd02-47f3-987b-e144973633d3" action="eval">
-                            <command>
-                                <body>set wsp [ regsub -all {\\\\}  $wsp /  ]</body>
-                            </command>
-                            <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
-                            <useFieldsInCommand>false</useFieldsInCommand>
-                        </item>
-                        <item guid="59f4ee68-abc5-4837-80ef-b947ae0d0e5b" action="eval">
-                            <command>
-                                <body>set projectList [file list file://$wsp/.metadata/.plugins/org.eclipse.core.resources/.projects]</body>
-                            </command>
-                            <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
-                            <useFieldsInCommand>false</useFieldsInCommand>
-                        </item>
-                    </nestedSteps>
+                    <postProcessing>
+                        <storeResponseAt>uriProjectList</storeResponseAt>
+                        <storeResponseText>true</storeResponseText>
+                    </postProcessing>
                     <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
                     <useFieldsInCommand>false</useFieldsInCommand>
                 </item>
-                <item guid="b917c382-391b-4f54-b0fd-0dd46f9330dc" action="comment">
+                <item guid="3d3d1c03-1ef5-480e-ba1a-5061a45ea853" action="foreach">
                     <command>
-                        <body>create documentation for each project in workspace</body>
+                        <body>uriProject $uriProjectList</body>
                     </command>
                     <nestedSteps>
-                        <item guid="93f7c4f3-773c-4f86-b86f-0d19581ab369" action="foreach" skippReporting="false">
+                        <item guid="45011257-207f-48f7-9ae6-fbb832900d40" action="if">
                             <command>
-                                <body>project $projectList</body>
+                                <body>![file exists $uriProject]</body>
                             </command>
                             <nestedSteps>
-                                <item guid="55d96b62-7479-46c6-83c5-01d2895d7970" action="if">
+                                <item guid="5f4edf1d-b8f0-4a6f-996e-a346000f9f83" action="then">
+                                    <nestedSteps>
+                                        <item guid="e5e22c64-8aac-4dac-891f-b612ce7f9ce2" action="comment">
+                                            <postProcessing>
+                                                <analysisRules>
+                                                    <item>
+                                                        <extractorInfo extractorType="none">
+                                                            <extractorProperties type="com.fnfr.svt.documents.EmptyExtractorPropertyGroup"/>
+                                                        </extractorInfo>
+                                                        <processorInfo ruleType="message">
+                                                            <ruleProperties type="com.fnfr.svt.execution.builtin.processors.MessageProcessorPropertyGroup" severity="Warning">
+                                                                <message>Project not found: $uriProject</message>
+                                                            </ruleProperties>
+                                                        </processorInfo>
+                                                    </item>
+                                                </analysisRules>
+                                            </postProcessing>
+                                            <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                                            <useFieldsInCommand>false</useFieldsInCommand>
+                                        </item>
+                                        <item guid="ed2f4cde-2f6f-4ff6-becd-ebfd02b1feb4" action="continue">
+                                            <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                                            <useFieldsInCommand>false</useFieldsInCommand>
+                                        </item>
+                                    </nestedSteps>
+                                    <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                                    <useFieldsInCommand>false</useFieldsInCommand>
+                                </item>
+                            </nestedSteps>
+                            <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                            <useFieldsInCommand>false</useFieldsInCommand>
+                        </item>
+                        <item guid="5212dd78-4f2b-4f06-8a70-9569facb1669" action="eval">
+                            <command>
+                                <body>set updateRequired 0</body>
+                            </command>
+                            <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                            <useFieldsInCommand>false</useFieldsInCommand>
+                        </item>
+                        <item guid="0784298b-994a-4cc9-a607-8d061cb6e53d" action="if">
+                            <command>
+                                <body>$uriProject == &quot;project://my_project&quot; || $uriProject == &quot;project://resources&quot; </body>
+                            </command>
+                            <nestedSteps>
+                                <item guid="21230c0c-0c22-4a92-abdf-98d72413646d" action="then">
+                                    <nestedSteps>
+                                        <item guid="c80b3c3f-0d97-4778-8a14-fc36b67e9b74" action="continue">
+                                            <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                                            <useFieldsInCommand>false</useFieldsInCommand>
+                                        </item>
+                                    </nestedSteps>
+                                    <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                                    <useFieldsInCommand>false</useFieldsInCommand>
+                                </item>
+                            </nestedSteps>
+                            <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                            <useFieldsInCommand>false</useFieldsInCommand>
+                        </item>
+                        <item guid="72c0c08a-a40a-45dd-91dd-6a9e0d085084" action="comment">
+                            <command>
+                                <body>Generate the documentation</body>
+                            </command>
+                            <nestedSteps>
+                                <item guid="e560193b-6680-4fde-858f-2ec93d0f28c4" action="call">
                                     <command>
-                                        <body>[regexp (.*projects/\\\\w\\\\w_) $project]</body>
+                                        <body>getUriList -uriPath $uriProject </body>
+                                    </command>
+                                    <postProcessing>
+                                        <storeResponseAt>uri_list</storeResponseAt>
+                                        <storeResponseText>true</storeResponseText>
+                                    </postProcessing>
+                                    <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                                    <useFieldsInCommand>false</useFieldsInCommand>
+                                </item>
+                                <item guid="a0648595-5bc6-40df-99b1-51d1cb072d1a" action="call">
+                                    <command>
+                                        <body>getLibList -uriList $uri_list</body>
+                                    </command>
+                                    <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                                    <useFieldsInCommand>false</useFieldsInCommand>
+                                </item>
+                                <item guid="ef519862-4f29-4c17-86ad-63e9dfe758d0" action="if">
+                                    <command>
+                                        <body>![gget CHANGE_BY_DATE]</body>
                                     </command>
                                     <nestedSteps>
-                                        <item guid="b0aa12a5-0750-472a-b56a-432ef1fc9540" action="then">
+                                        <item guid="fc9bd972-2b3a-46f9-a732-bbf39a90daa7" action="then">
                                             <nestedSteps>
-                                                <item guid="91999a3c-1578-40e6-a1f9-884128110dd8" action="comment">
+                                                <item guid="7b4ad857-7414-4161-8c9e-500badbb5efa" action="eval">
                                                     <command>
-                                                        <body>initialize variables</body>
+                                                        <body>set uri $uriProject/documentation/readme.txt</body>
                                                     </command>
-                                                    <nestedSteps>
-                                                        <item guid="fa0921c3-d535-4257-8c52-ec48ce9f273d" action="eval">
-                                                            <command>
-                                                                <body>set uriPath project://[lindex [split $project /] end-1]</body>
-                                                            </command>
-                                                            <postProcessing>
-                                                                <analysisRules>
-                                                                    <item>
-                                                                        <extractorInfo extractorType="none">
-                                                                            <extractorProperties type="com.fnfr.svt.documents.EmptyExtractorPropertyGroup"/>
-                                                                        </extractorInfo>
-                                                                        <processorInfo ruleType="message">
-                                                                            <ruleProperties type="com.fnfr.svt.execution.builtin.processors.MessageProcessorPropertyGroup" severity="Information">
-                                                                                <message>Creating documentation for: $uriPath</message>
-                                                                            </ruleProperties>
-                                                                        </processorInfo>
-                                                                    </item>
-                                                                </analysisRules>
-                                                            </postProcessing>
-                                                            <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
-                                                            <useFieldsInCommand>false</useFieldsInCommand>
-                                                        </item>
-                                                        <item guid="5d854858-e22c-482a-86b5-b122f49937be" action="eval">
-                                                            <command>
-                                                                <body>set qcList {}</body>
-                                                            </command>
-                                                            <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
-                                                            <useFieldsInCommand>false</useFieldsInCommand>
-                                                        </item>
-                                                        <item guid="0d00f1cf-c972-4866-b33a-6a76e0eb0249" action="eval">
-                                                            <command>
-                                                                <body>set fileList {}</body>
-                                                            </command>
-                                                            <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
-                                                            <useFieldsInCommand>false</useFieldsInCommand>
-                                                        </item>
-                                                    </nestedSteps>
                                                     <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
                                                     <useFieldsInCommand>false</useFieldsInCommand>
                                                 </item>
-                                                <item guid="6e60dff3-0297-4c7f-92c3-042f728f7deb" action="comment">
+                                                <item guid="1b85374b-a953-4ef7-ae2a-b330eea22b7b" action="if">
                                                     <command>
-                                                        <body>Get the list of files in the URI path</body>
+                                                        <body>![file exists $uri]</body>
                                                     </command>
                                                     <nestedSteps>
-                                                        <item guid="5ac642f9-6c7b-4240-b7b0-807c75928315" action="eval">
-                                                            <command>
-                                                                <body>puts [file list -r -nolimit $uriPath]</body>
-                                                            </command>
-                                                            <postProcessing>
-                                                                <storeResponseAt>fileList</storeResponseAt>
-                                                            </postProcessing>
-                                                            <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
-                                                            <useFieldsInCommand>false</useFieldsInCommand>
-                                                        </item>
-                                                        <item guid="1baa4638-e7b6-458c-8b88-032300714a6e" action="eval">
-                                                            <command>
-                                                                <body>set foundNewFile false</body>
-                                                            </command>
-                                                            <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
-                                                            <useFieldsInCommand>false</useFieldsInCommand>
-                                                        </item>
-                                                    </nestedSteps>
-                                                    <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
-                                                    <useFieldsInCommand>false</useFieldsInCommand>
-                                                </item>
-                                                <item guid="79d446d5-9cc2-4d07-a18b-8583d8d0719f" action="foreach">
-                                                    <command>
-                                                        <body>projFileName [response fileList]</body>
-                                                    </command>
-                                                    <nestedSteps>
-                                                        <item guid="e5cea129-48f6-46eb-bfbc-f0650fc672af" action="if">
-                                                            <command>
-                                                                <body>[string match *.fftc $projFileName] || [string match *readme.txt $projFileName]</body>
-                                                            </command>
+                                                        <item guid="42fe4e4d-6a39-4820-8458-25ec385e52d2" action="then">
                                                             <nestedSteps>
-                                                                <item guid="2e5d3b93-187a-46ec-a016-a681ab1d52d7" action="then">
+                                                                <item guid="aea038b9-a1f3-48fd-8f79-8b9d2643df95" action="comment">
+                                                                    <postProcessing>
+                                                                        <analysisRules>
+                                                                            <item>
+                                                                                <extractorInfo extractorType="none">
+                                                                                    <extractorProperties type="com.fnfr.svt.documents.EmptyExtractorPropertyGroup"/>
+                                                                                </extractorInfo>
+                                                                                <processorInfo ruleType="assert">
+                                                                                    <ruleProperties type="com.fnfr.svt.execution.builtin.processors.AssertionPropertyGroup">
+                                                                                        <expression>1</expression>
+                                                                                        <actionsWhenTrue>
+                                                                                            <item actionId="DeclareExecutionIssue">
+                                                                                                <actionProperties type="com.fnfr.svt.execution.builtin.actions.ExecutionIssuePropertyGroup">
+                                                                                                    <message>File not found: $uri</message>
+                                                                                                </actionProperties>
+                                                                                            </item>
+                                                                                            <item actionId="FailTest">
+                                                                                                <actionProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                                                                                            </item>
+                                                                                        </actionsWhenTrue>
+                                                                                    </ruleProperties>
+                                                                                </processorInfo>
+                                                                            </item>
+                                                                            <item>
+                                                                                <extractorInfo extractorType="none">
+                                                                                    <extractorProperties type="com.fnfr.svt.documents.EmptyExtractorPropertyGroup"/>
+                                                                                </extractorInfo>
+                                                                                <processorInfo ruleType="message">
+                                                                                    <ruleProperties type="com.fnfr.svt.execution.builtin.processors.MessageProcessorPropertyGroup" severity="Warning">
+                                                                                        <message>This file should contain the following information:</message>
+                                                                                    </ruleProperties>
+                                                                                </processorInfo>
+                                                                            </item>
+                                                                            <item>
+                                                                                <extractorInfo extractorType="none">
+                                                                                    <extractorProperties type="com.fnfr.svt.documents.EmptyExtractorPropertyGroup"/>
+                                                                                </extractorInfo>
+                                                                                <processorInfo ruleType="message">
+                                                                                    <ruleProperties type="com.fnfr.svt.execution.builtin.processors.MessageProcessorPropertyGroup" severity="Warning">
+                                                                                        <message>Project: &lt;name&gt;</message>
+                                                                                    </ruleProperties>
+                                                                                </processorInfo>
+                                                                            </item>
+                                                                            <item>
+                                                                                <extractorInfo extractorType="none">
+                                                                                    <extractorProperties type="com.fnfr.svt.documents.EmptyExtractorPropertyGroup"/>
+                                                                                </extractorInfo>
+                                                                                <processorInfo ruleType="message">
+                                                                                    <ruleProperties type="com.fnfr.svt.execution.builtin.processors.MessageProcessorPropertyGroup" severity="Warning">
+                                                                                        <message>Description: &lt;Some wording about what the project does or is used for&gt;</message>
+                                                                                    </ruleProperties>
+                                                                                </processorInfo>
+                                                                            </item>
+                                                                            <item>
+                                                                                <extractorInfo extractorType="none">
+                                                                                    <extractorProperties type="com.fnfr.svt.documents.EmptyExtractorPropertyGroup"/>
+                                                                                </extractorInfo>
+                                                                                <processorInfo ruleType="message">
+                                                                                    <ruleProperties type="com.fnfr.svt.execution.builtin.processors.MessageProcessorPropertyGroup" severity="Warning">
+                                                                                        <message>Category: &lt;&quot;library&quot;, &quot;automation&quot;, or &quot;framework&quot;&gt;</message>
+                                                                                    </ruleProperties>
+                                                                                </processorInfo>
+                                                                            </item>
+                                                                            <item>
+                                                                                <extractorInfo extractorType="none">
+                                                                                    <extractorProperties type="com.fnfr.svt.documents.EmptyExtractorPropertyGroup"/>
+                                                                                </extractorInfo>
+                                                                                <processorInfo ruleType="message">
+                                                                                    <ruleProperties type="com.fnfr.svt.execution.builtin.processors.MessageProcessorPropertyGroup" severity="Warning">
+                                                                                        <message>Class: &lt;&quot;Community&quot;, &quot;Tested by Spirent&quot;, &quot;Reference&quot;&gt;</message>
+                                                                                    </ruleProperties>
+                                                                                </processorInfo>
+                                                                            </item>
+                                                                        </analysisRules>
+                                                                    </postProcessing>
+                                                                    <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                                                                    <useFieldsInCommand>false</useFieldsInCommand>
+                                                                </item>
+                                                                <item guid="751a2f89-0a49-4b7a-be29-432478fb208b" action="exit" skip="true">
+                                                                    <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                                                                    <useFieldsInCommand>false</useFieldsInCommand>
+                                                                </item>
+                                                            </nestedSteps>
+                                                            <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                                                            <useFieldsInCommand>false</useFieldsInCommand>
+                                                        </item>
+                                                        <item guid="62470622-aeb9-4b91-91f3-ba1a8c9d3cf2" action="else">
+                                                            <nestedSteps>
+                                                                <item guid="e69b2141-dd8e-40d7-9040-3b4c6c041e8c" action="call">
+                                                                    <command>
+                                                                        <body>fileChanged -uri $uri</body>
+                                                                    </command>
+                                                                    <postProcessing>
+                                                                        <storeResponseAt>changed</storeResponseAt>
+                                                                        <storeResponseText>true</storeResponseText>
+                                                                    </postProcessing>
+                                                                    <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                                                                    <useFieldsInCommand>false</useFieldsInCommand>
+                                                                </item>
+                                                                <item guid="157ad711-3cc1-4ef2-92ff-98cc916f2030" action="if">
+                                                                    <command>
+                                                                        <body>$changed</body>
+                                                                    </command>
                                                                     <nestedSteps>
-                                                                        <item guid="79897279-e6b9-48e2-853c-4d3f358ee250" action="comment">
+                                                                        <item guid="b54f6c6f-e5a8-45e7-94ea-b1cd34311db8" action="then">
                                                                             <nestedSteps>
-                                                                                <item guid="a88406b4-87f4-41f2-b827-a0f54c569f81" action="eval">
+                                                                                <item guid="9f6c1908-422d-4a93-9446-20d83b3bdec4" action="eval">
                                                                                     <command>
-                                                                                        <body>set fullFileName [file uriToPath $projFileName]</body>
+                                                                                        <body>set updateRequired 1</body>
                                                                                     </command>
                                                                                     <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
                                                                                     <useFieldsInCommand>false</useFieldsInCommand>
-                                                                                </item>
-                                                                                <item guid="d6112a1e-2201-4f0f-8094-e140c952bb23" action="command" session="tcl1">
-                                                                                    <command>
-                                                                                        <body>file mtime {$fullFileName}</body>
-                                                                                    </command>
-                                                                                    <postProcessing>
-                                                                                        <analysisRules>
-                                                                                            <item>
-                                                                                                <extractorInfo extractorType="regex">
-                                                                                                    <extractorProperties type="com.fnfr.svt.mapping.regex.extractors.RegexExtractorPropertyGroup" useLineMode="true">
-                                                                                                        <regex>^(\\d+)$</regex>
-                                                                                                    </extractorProperties>
-                                                                                                </extractorInfo>
-                                                                                                <processorInfo ruleType="assert">
-                                                                                                    <ruleProperties type="com.fnfr.svt.execution.builtin.processors.AssertionPropertyGroup">
-                                                                                                        <expression>$value &gt;= $changeSeconds</expression>
-                                                                                                        <actionsWhenTrue>
-                                                                                                            <item actionId="Eval">
-                                                                                                                <actionProperties type="com.fnfr.svt.execution.builtin.actions.EvalActionPropertyGroup">
-                                                                                                                    <statement>set foundNewFile true</statement>
-                                                                                                                </actionProperties>
-                                                                                                            </item>
-                                                                                                            <item actionId="DeclareExecutionIssue">
-                                                                                                                <actionProperties type="com.fnfr.svt.execution.builtin.actions.ExecutionIssuePropertyGroup" severity="Information">
-                                                                                                                    <message>    Found recently changed file $projFileName</message>
-                                                                                                                </actionProperties>
-                                                                                                            </item>
-                                                                                                        </actionsWhenTrue>
-                                                                                                    </ruleProperties>
-                                                                                                </processorInfo>
-                                                                                            </item>
-                                                                                        </analysisRules>
-                                                                                    </postProcessing>
-                                                                                    <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
                                                                                 </item>
                                                                             </nestedSteps>
                                                                             <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
@@ -243,21 +398,859 @@
                                                     <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
                                                     <useFieldsInCommand>false</useFieldsInCommand>
                                                 </item>
-                                                <item guid="2eb33447-02d9-40f9-a103-5ed05b303b4c" action="if">
+                                                <item guid="0528c21b-7fca-4277-94d4-431dd39d4c2c" action="foreach">
                                                     <command>
-                                                        <body>$foundNewFile</body>
+                                                        <body>uri [gget QC_LIB_URI_LIST]</body>
                                                     </command>
                                                     <nestedSteps>
-                                                        <item guid="c31bf2c8-fcaf-4421-a218-441d48d28955" action="then">
+                                                        <item guid="0f634f5b-750c-424a-9ab6-e3a64e9d68f3" action="call">
+                                                            <command>
+                                                                <body>fileChanged -uri $uri</body>
+                                                            </command>
+                                                            <postProcessing>
+                                                                <storeResponseAt>changed</storeResponseAt>
+                                                                <storeResponseText>true</storeResponseText>
+                                                            </postProcessing>
+                                                            <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                                                            <useFieldsInCommand>false</useFieldsInCommand>
+                                                        </item>
+                                                        <item guid="1246bf94-7124-4db6-a29f-641bb7857b6c" action="if">
+                                                            <command>
+                                                                <body>$changed</body>
+                                                            </command>
                                                             <nestedSteps>
-                                                                <item guid="6f06e8e2-7123-4181-b5f6-28438e7f43d7" action="comment">
-                                                                    <command>
-                                                                        <body>Initial HTML page creation</body>
-                                                                    </command>
+                                                                <item guid="2e85c750-6970-47b9-8ce5-5621ee970c84" action="then">
                                                                     <nestedSteps>
-                                                                        <item guid="bb4186a2-385f-4b1c-bcf6-124f22fedd4d" action="writeFile">
+                                                                        <item guid="d9d045de-6532-4e5a-941c-0e665fb4998e" action="eval">
                                                                             <command>
-                                                                                <body>$uriPath/documentation/index.html &quot;&lt;HTML&gt;&lt;BODY&gt;
+                                                                                <body>set updateRequired 1</body>
+                                                                            </command>
+                                                                            <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                                                                            <useFieldsInCommand>false</useFieldsInCommand>
+                                                                        </item>
+                                                                    </nestedSteps>
+                                                                    <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                                                                    <useFieldsInCommand>false</useFieldsInCommand>
+                                                                </item>
+                                                            </nestedSteps>
+                                                            <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                                                            <useFieldsInCommand>false</useFieldsInCommand>
+                                                        </item>
+                                                    </nestedSteps>
+                                                    <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                                                    <useFieldsInCommand>false</useFieldsInCommand>
+                                                </item>
+                                                <item guid="dba68b97-bbfb-48e5-8ff9-d681e1047c45" action="foreach">
+                                                    <command>
+                                                        <body>uri [gget PROC_LIB_URI_LIST]</body>
+                                                    </command>
+                                                    <nestedSteps>
+                                                        <item guid="62159568-b122-4a2f-8e67-9ca1f7721a5b" action="call">
+                                                            <command>
+                                                                <body>fileChanged -uri $uri</body>
+                                                            </command>
+                                                            <postProcessing>
+                                                                <storeResponseAt>changed</storeResponseAt>
+                                                                <storeResponseText>true</storeResponseText>
+                                                            </postProcessing>
+                                                            <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                                                            <useFieldsInCommand>false</useFieldsInCommand>
+                                                        </item>
+                                                        <item guid="961162b0-34aa-4988-879f-df2de55dc25f" action="if">
+                                                            <command>
+                                                                <body>$changed</body>
+                                                            </command>
+                                                            <nestedSteps>
+                                                                <item guid="fdb94743-2b9e-4b36-af5e-8fe3d8e57415" action="then">
+                                                                    <nestedSteps>
+                                                                        <item guid="24342f22-e4fd-4f7c-aa79-cc8b71c9672d" action="eval">
+                                                                            <command>
+                                                                                <body>set updateRequired 1</body>
+                                                                            </command>
+                                                                            <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                                                                            <useFieldsInCommand>false</useFieldsInCommand>
+                                                                        </item>
+                                                                    </nestedSteps>
+                                                                    <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                                                                    <useFieldsInCommand>false</useFieldsInCommand>
+                                                                </item>
+                                                            </nestedSteps>
+                                                            <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                                                            <useFieldsInCommand>false</useFieldsInCommand>
+                                                        </item>
+                                                    </nestedSteps>
+                                                    <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                                                    <useFieldsInCommand>false</useFieldsInCommand>
+                                                </item>
+                                                <item guid="eb1d0e14-02e8-40f3-98e2-92fba45fa754" action="foreach">
+                                                    <command>
+                                                        <body>uri [gget RM_LIB_URI_LIST]</body>
+                                                    </command>
+                                                    <nestedSteps>
+                                                        <item guid="21568f68-f279-4a2d-9142-4d2910825093" action="call">
+                                                            <command>
+                                                                <body>fileChanged -uri $uri</body>
+                                                            </command>
+                                                            <postProcessing>
+                                                                <storeResponseAt>changed</storeResponseAt>
+                                                                <storeResponseText>true</storeResponseText>
+                                                            </postProcessing>
+                                                            <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                                                            <useFieldsInCommand>false</useFieldsInCommand>
+                                                        </item>
+                                                        <item guid="f02e30eb-1843-4efb-b972-f2cdb4813ca2" action="if">
+                                                            <command>
+                                                                <body>$changed</body>
+                                                            </command>
+                                                            <nestedSteps>
+                                                                <item guid="0bbdc6bb-ff95-4e55-8cfb-9b24fba46ec5" action="then">
+                                                                    <nestedSteps>
+                                                                        <item guid="5168014a-2370-46ba-aec5-8a892f0273d5" action="eval">
+                                                                            <command>
+                                                                                <body>set updateRequired 1</body>
+                                                                            </command>
+                                                                            <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                                                                            <useFieldsInCommand>false</useFieldsInCommand>
+                                                                        </item>
+                                                                    </nestedSteps>
+                                                                    <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                                                                    <useFieldsInCommand>false</useFieldsInCommand>
+                                                                </item>
+                                                            </nestedSteps>
+                                                            <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                                                            <useFieldsInCommand>false</useFieldsInCommand>
+                                                        </item>
+                                                    </nestedSteps>
+                                                    <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                                                    <useFieldsInCommand>false</useFieldsInCommand>
+                                                </item>
+                                            </nestedSteps>
+                                            <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                                            <useFieldsInCommand>false</useFieldsInCommand>
+                                        </item>
+                                    </nestedSteps>
+                                    <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                                    <useFieldsInCommand>false</useFieldsInCommand>
+                                </item>
+                                <item guid="2dcfe6aa-f002-41aa-805a-1c0ea4d67483" action="if">
+                                    <command>
+                                        <body>$updateRequired</body>
+                                    </command>
+                                    <nestedSteps>
+                                        <item guid="0e593198-8209-4b82-8b79-c290952d5a23" action="then">
+                                            <nestedSteps>
+                                                <item guid="77c1acd2-fdd9-45fc-96fb-322a36b6d011" action="call">
+                                                    <command>
+                                                        <body>createFiles -uriPath $uriProject</body>
+                                                    </command>
+                                                    <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                                                    <useFieldsInCommand>false</useFieldsInCommand>
+                                                </item>
+                                                <item guid="0b07ad0e-add9-47a6-aca8-c63df8423719" action="call">
+                                                    <command>
+                                                        <body>writeLibrariesFound -uriPath $uriProject</body>
+                                                    </command>
+                                                    <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                                                    <useFieldsInCommand>false</useFieldsInCommand>
+                                                </item>
+                                                <item guid="0e6ee5d8-3eef-4e8b-96a3-447685055ff6" action="call">
+                                                    <command>
+                                                        <body>writeInfo -uriPath $uriProject -uriList [gget QC_LIB_URI_LIST]</body>
+                                                    </command>
+                                                    <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                                                    <useFieldsInCommand>false</useFieldsInCommand>
+                                                </item>
+                                                <item guid="61cbdf5b-f041-4b84-8598-13214976c563" action="call">
+                                                    <command>
+                                                        <body>writeInfo -uriPath $uriProject -uriList [gget PROC_LIB_URI_LIST]</body>
+                                                    </command>
+                                                    <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                                                    <useFieldsInCommand>false</useFieldsInCommand>
+                                                </item>
+                                                <item guid="bebc7177-c7ab-4b7d-8f43-bd72a16ed93b" action="if">
+                                                    <command>
+                                                        <body>[param includeResponseMaps] == &quot;true&quot;</body>
+                                                    </command>
+                                                    <nestedSteps>
+                                                        <item guid="1cf0ac6a-f2b5-4d98-ae60-537ab11a240e" action="then">
+                                                            <nestedSteps>
+                                                                <item guid="424f94ac-b964-4cec-b0d7-5920a411fcc5" action="call">
+                                                                    <command>
+                                                                        <body>writeRMInfo -uriPath $uriProject -uriList [gget RM_LIB_URI_LIST]</body>
+                                                                    </command>
+                                                                    <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                                                                    <useFieldsInCommand>false</useFieldsInCommand>
+                                                                </item>
+                                                            </nestedSteps>
+                                                            <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                                                            <useFieldsInCommand>false</useFieldsInCommand>
+                                                        </item>
+                                                    </nestedSteps>
+                                                    <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                                                    <useFieldsInCommand>false</useFieldsInCommand>
+                                                </item>
+                                                <item guid="54d88ede-8e36-4325-aaa9-54b55e8a8c2a" action="if">
+                                                    <command>
+                                                        <body>[llength [gget QC_LIB_URI_LIST]] &gt; 0 || [llength [gget PROC_LIB_URI_LIST]] &gt; 0 || [llength [gget RM_LIB_URI_LIST]] &gt; 0</body>
+                                                    </command>
+                                                    <nestedSteps>
+                                                        <item guid="51577d1b-f3b5-4f9c-bae9-cce7e64d54ca" action="then">
+                                                            <nestedSteps>
+                                                                <item guid="1b067e76-661e-47e7-a363-89f24dbff9b6" action="comment">
+                                                                    <postProcessing>
+                                                                        <analysisRules>
+                                                                            <item>
+                                                                                <extractorInfo extractorType="none">
+                                                                                    <extractorProperties type="com.fnfr.svt.documents.EmptyExtractorPropertyGroup"/>
+                                                                                </extractorInfo>
+                                                                                <processorInfo ruleType="message">
+                                                                                    <ruleProperties type="com.fnfr.svt.execution.builtin.processors.MessageProcessorPropertyGroup" severity="Information">
+                                                                                        <message>Documentation files created:</message>
+                                                                                    </ruleProperties>
+                                                                                </processorInfo>
+                                                                            </item>
+                                                                            <item>
+                                                                                <extractorInfo extractorType="none">
+                                                                                    <extractorProperties type="com.fnfr.svt.documents.EmptyExtractorPropertyGroup"/>
+                                                                                </extractorInfo>
+                                                                                <processorInfo ruleType="message">
+                                                                                    <ruleProperties type="com.fnfr.svt.execution.builtin.processors.MessageProcessorPropertyGroup" severity="Information">
+                                                                                        <message>  $uriProject/documentation/index.html</message>
+                                                                                    </ruleProperties>
+                                                                                </processorInfo>
+                                                                            </item>
+                                                                            <item>
+                                                                                <extractorInfo extractorType="none">
+                                                                                    <extractorProperties type="com.fnfr.svt.documents.EmptyExtractorPropertyGroup"/>
+                                                                                </extractorInfo>
+                                                                                <processorInfo ruleType="message">
+                                                                                    <ruleProperties type="com.fnfr.svt.execution.builtin.processors.MessageProcessorPropertyGroup" severity="Information">
+                                                                                        <message>  $uriProject/README.md</message>
+                                                                                    </ruleProperties>
+                                                                                </processorInfo>
+                                                                            </item>
+                                                                        </analysisRules>
+                                                                    </postProcessing>
+                                                                    <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                                                                    <useFieldsInCommand>false</useFieldsInCommand>
+                                                                </item>
+                                                            </nestedSteps>
+                                                            <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                                                            <useFieldsInCommand>false</useFieldsInCommand>
+                                                        </item>
+                                                        <item guid="dd97dd45-8895-43d1-8cef-7590ce1bd843" action="else">
+                                                            <nestedSteps>
+                                                                <item guid="8e91bd77-8734-4587-bc65-834d64d8d939" action="comment">
+                                                                    <postProcessing>
+                                                                        <analysisRules>
+                                                                            <item>
+                                                                                <extractorInfo extractorType="none">
+                                                                                    <extractorProperties type="com.fnfr.svt.documents.EmptyExtractorPropertyGroup"/>
+                                                                                </extractorInfo>
+                                                                                <processorInfo ruleType="message">
+                                                                                    <ruleProperties type="com.fnfr.svt.execution.builtin.processors.MessageProcessorPropertyGroup" severity="Information">
+                                                                                        <message>Nothing found to document: $uriProject </message>
+                                                                                    </ruleProperties>
+                                                                                </processorInfo>
+                                                                            </item>
+                                                                        </analysisRules>
+                                                                    </postProcessing>
+                                                                    <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                                                                    <useFieldsInCommand>false</useFieldsInCommand>
+                                                                </item>
+                                                            </nestedSteps>
+                                                            <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                                                            <useFieldsInCommand>false</useFieldsInCommand>
+                                                        </item>
+                                                    </nestedSteps>
+                                                    <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                                                    <useFieldsInCommand>false</useFieldsInCommand>
+                                                </item>
+                                            </nestedSteps>
+                                            <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                                            <useFieldsInCommand>false</useFieldsInCommand>
+                                        </item>
+                                        <item guid="01863b7c-741d-4e51-afad-2f8c63b5adae" action="else">
+                                            <nestedSteps>
+                                                <item guid="8238527b-ab2a-451b-a5fc-596e3276d1bd" action="comment">
+                                                    <postProcessing>
+                                                        <analysisRules>
+                                                            <item>
+                                                                <extractorInfo extractorType="none">
+                                                                    <extractorProperties type="com.fnfr.svt.documents.EmptyExtractorPropertyGroup"/>
+                                                                </extractorInfo>
+                                                                <processorInfo ruleType="message">
+                                                                    <ruleProperties type="com.fnfr.svt.execution.builtin.processors.MessageProcessorPropertyGroup" severity="Information">
+                                                                        <message>Documentation has not changed since [param changedDate]: $uriProject</message>
+                                                                    </ruleProperties>
+                                                                </processorInfo>
+                                                            </item>
+                                                        </analysisRules>
+                                                    </postProcessing>
+                                                    <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                                                    <useFieldsInCommand>false</useFieldsInCommand>
+                                                </item>
+                                            </nestedSteps>
+                                            <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                                            <useFieldsInCommand>false</useFieldsInCommand>
+                                        </item>
+                                    </nestedSteps>
+                                    <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                                    <useFieldsInCommand>false</useFieldsInCommand>
+                                </item>
+                            </nestedSteps>
+                            <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                            <useFieldsInCommand>false</useFieldsInCommand>
+                        </item>
+                    </nestedSteps>
+                    <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                    <useFieldsInCommand>false</useFieldsInCommand>
+                </item>
+                <item guid="b74dea24-9659-40cb-97bb-673adcd4ab6e" action="comment">
+                    <postProcessing>
+                        <analysisRules>
+                            <item>
+                                <extractorInfo extractorType="none">
+                                    <extractorProperties type="com.fnfr.svt.documents.EmptyExtractorPropertyGroup"/>
+                                </extractorInfo>
+                                <processorInfo ruleType="assert">
+                                    <ruleProperties type="com.fnfr.svt.execution.builtin.processors.AssertionPropertyGroup">
+                                        <expression>[info status] != &quot;Fail&quot;</expression>
+                                        <actionsWhenTrue>
+                                            <item actionId="DeclareExecutionIssue">
+                                                <actionProperties type="com.fnfr.svt.execution.builtin.actions.ExecutionIssuePropertyGroup" severity="OK">
+                                                    <message>Documentation generation complete</message>
+                                                </actionProperties>
+                                            </item>
+                                            <item actionId="PassTestIfNotAlreadyFailed">
+                                                <actionProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                                            </item>
+                                        </actionsWhenTrue>
+                                    </ruleProperties>
+                                </processorInfo>
+                            </item>
+                        </analysisRules>
+                    </postProcessing>
+                    <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                    <useFieldsInCommand>false</useFieldsInCommand>
+                </item>
+            </steps>
+        </item>
+        <item name="getProjectList">
+            <description>Get a list of all projects in workspace</description>
+            <steps>
+                <item guid="8b484468-5343-4ad7-a1d7-1433b973cd4e" action="eval">
+                    <command>
+                        <body>set uri [param uriDocumentationList &quot;&quot;]</body>
+                    </command>
+                    <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                    <useFieldsInCommand>false</useFieldsInCommand>
+                </item>
+                <item guid="5292f84b-f599-4bce-8fb0-dcec9805ecae" action="if">
+                    <command>
+                        <body>[file exists $uri]</body>
+                    </command>
+                    <nestedSteps>
+                        <item guid="30ab3d9e-7ef4-4e84-a0e0-4de8308546cc" action="then">
+                            <nestedSteps>
+                                <item guid="79a6fbc5-65bf-4ae6-ac8f-af878810ed94" action="comment">
+                                    <command>
+                                        <body>Extract the list from text file</body>
+                                    </command>
+                                    <postProcessing>
+                                        <analysisRules>
+                                            <item>
+                                                <extractorInfo extractorType="none">
+                                                    <extractorProperties type="com.fnfr.svt.documents.EmptyExtractorPropertyGroup"/>
+                                                </extractorInfo>
+                                                <processorInfo ruleType="message">
+                                                    <ruleProperties type="com.fnfr.svt.execution.builtin.processors.MessageProcessorPropertyGroup" severity="Information">
+                                                        <message>Reading project list from: [file uriToPath $uri]</message>
+                                                    </ruleProperties>
+                                                </processorInfo>
+                                            </item>
+                                        </analysisRules>
+                                    </postProcessing>
+                                    <nestedSteps>
+                                        <item guid="2ba2b7b0-90ca-44b6-bdeb-be3d8a5ce245" action="readFile">
+                                            <command>
+                                                <body>$uri</body>
+                                            </command>
+                                            <postProcessing>
+                                                <storeResponseAt>lines</storeResponseAt>
+                                                <storeResponseText>true</storeResponseText>
+                                            </postProcessing>
+                                            <applicationProperties type="com.fnfr.svt.execution.builtin.exec.ReadFilePropertyGroup"/>
+                                        </item>
+                                        <item guid="645fc1d9-0557-4ab4-b477-4f39a415e7c5" action="foreach">
+                                            <command>
+                                                <body>uriPath [split $lines \\n]</body>
+                                            </command>
+                                            <nestedSteps>
+                                                <item guid="ac14be22-2849-4e45-a4e5-d893b2efab3e" action="eval">
+                                                    <command>
+                                                        <body>set uriPath [string trim $uriPath]</body>
+                                                    </command>
+                                                    <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                                                    <useFieldsInCommand>false</useFieldsInCommand>
+                                                </item>
+                                                <item guid="7482e8d0-2c2c-4054-b4e7-dc32af594ffe" action="if">
+                                                    <command>
+                                                        <body>$uriPath != &quot;&quot;</body>
+                                                    </command>
+                                                    <nestedSteps>
+                                                        <item guid="6bf812f0-779c-4016-82f2-435c56bfaa4d" action="then">
+                                                            <nestedSteps>
+                                                                <item guid="48e08b65-6cbb-47f6-9368-ec9d20c21cf9" action="eval">
+                                                                    <command>
+                                                                        <body>lappend uri_list $uriPath</body>
+                                                                    </command>
+                                                                    <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                                                                    <useFieldsInCommand>false</useFieldsInCommand>
+                                                                </item>
+                                                            </nestedSteps>
+                                                            <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                                                            <useFieldsInCommand>false</useFieldsInCommand>
+                                                        </item>
+                                                    </nestedSteps>
+                                                    <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                                                    <useFieldsInCommand>false</useFieldsInCommand>
+                                                </item>
+                                            </nestedSteps>
+                                            <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                                            <useFieldsInCommand>false</useFieldsInCommand>
+                                        </item>
+                                    </nestedSteps>
+                                    <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                                    <useFieldsInCommand>false</useFieldsInCommand>
+                                </item>
+                            </nestedSteps>
+                            <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                            <useFieldsInCommand>false</useFieldsInCommand>
+                        </item>
+                        <item guid="34df12f6-5ec5-49cc-8175-be7bd09f6ba6" action="else">
+                            <nestedSteps>
+                                <item guid="a9f06bd8-c784-46aa-8a50-33f8233048ce" action="comment">
+                                    <command>
+                                        <body>Extract the list from .projects file</body>
+                                    </command>
+                                    <postProcessing>
+                                        <analysisRules>
+                                            <item>
+                                                <extractorInfo extractorType="none">
+                                                    <extractorProperties type="com.fnfr.svt.documents.EmptyExtractorPropertyGroup"/>
+                                                </extractorInfo>
+                                                <processorInfo ruleType="message">
+                                                    <ruleProperties type="com.fnfr.svt.execution.builtin.processors.MessageProcessorPropertyGroup" severity="Information">
+                                                        <message>Reading project list from metadata</message>
+                                                    </ruleProperties>
+                                                </processorInfo>
+                                            </item>
+                                        </analysisRules>
+                                    </postProcessing>
+                                    <nestedSteps>
+                                        <item guid="0682ec6b-fb7a-47cc-85b1-0d66098ee9eb" action="eval">
+                                            <command>
+                                                <body>set wsp [ info workspacePath ]</body>
+                                            </command>
+                                            <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                                            <useFieldsInCommand>false</useFieldsInCommand>
+                                        </item>
+                                        <item guid="c44993ea-de42-453f-ba73-7849d3a637e5" action="eval">
+                                            <command>
+                                                <body>set wsp [ regsub -all {\\\\}  $wsp /  ]</body>
+                                            </command>
+                                            <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                                            <useFieldsInCommand>false</useFieldsInCommand>
+                                        </item>
+                                        <item guid="8dc071bd-bfa6-4d16-a78d-4ce4121a2265" action="eval">
+                                            <command>
+                                                <body>set project_list [file list file://$wsp/.metadata/.plugins/org.eclipse.core.resources/.projects]</body>
+                                            </command>
+                                            <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                                            <useFieldsInCommand>false</useFieldsInCommand>
+                                        </item>
+                                        <item guid="28ea7976-1290-4292-896a-34cea900660a" action="foreach">
+                                            <command>
+                                                <body>uriPath $project_list</body>
+                                            </command>
+                                            <nestedSteps>
+                                                <item guid="ae07ac5e-f231-4d32-ae36-d9a80cbbe515" action="eval">
+                                                    <command>
+                                                        <body>lappend uri_list project://[lindex [split $uriPath /] end-1]</body>
+                                                    </command>
+                                                    <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                                                    <useFieldsInCommand>false</useFieldsInCommand>
+                                                </item>
+                                            </nestedSteps>
+                                            <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                                            <useFieldsInCommand>false</useFieldsInCommand>
+                                        </item>
+                                    </nestedSteps>
+                                    <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                                    <useFieldsInCommand>false</useFieldsInCommand>
+                                </item>
+                            </nestedSteps>
+                            <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                            <useFieldsInCommand>false</useFieldsInCommand>
+                        </item>
+                    </nestedSteps>
+                    <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                    <useFieldsInCommand>false</useFieldsInCommand>
+                </item>
+                <item guid="696ec3d9-575a-44fc-93e9-90bb7b2e246e" action="return">
+                    <command>
+                        <body>$uri_list</body>
+                    </command>
+                    <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                </item>
+            </steps>
+            <multilineDescription>Return a list of project URI&apos;s within the current workspace</multilineDescription>
+        </item>
+        <item name="getUriList">
+            <description>Get list of file URI&apos;s to get documentation from</description>
+            <steps>
+                <item guid="ccdef2a6-6886-4720-9b9a-3170ab76ec4d" action="eval">
+                    <command>
+                        <body>set tc_uri_list {}</body>
+                    </command>
+                    <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                    <useFieldsInCommand>false</useFieldsInCommand>
+                </item>
+                <item guid="a9233822-35a7-4dc9-8fdc-2048bad35f40" action="if">
+                    <command>
+                        <body>$uriPath != &quot;project://my_project&quot; &amp;&amp; $uriPath != &quot;project://resources&quot; </body>
+                    </command>
+                    <nestedSteps>
+                        <item guid="6f878613-1874-4b7e-aeac-d09ccfe1019f" action="then">
+                            <nestedSteps>
+                                <item guid="828c49d9-316e-4144-a98f-27521e7b1edb" action="eval">
+                                    <command>
+                                        <body>set file_uri_list [file list -r -nolimit $uriPath]</body>
+                                    </command>
+                                    <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                                    <useFieldsInCommand>false</useFieldsInCommand>
+                                </item>
+                                <item guid="16e90cf7-a945-4248-8a9e-d3a688f4468e" action="foreach">
+                                    <command>
+                                        <body>file_uri $file_uri_list</body>
+                                    </command>
+                                    <nestedSteps>
+                                        <item guid="316c1adb-90fc-4740-8da2-afbb08c97cda" action="if">
+                                            <command>
+                                                <body>[string match *.fftc $file_uri] || [string match *.ffrm $file_uri]</body>
+                                            </command>
+                                            <nestedSteps>
+                                                <item guid="a086838a-ce25-4ff8-82e9-f363d4a2f02e" action="then">
+                                                    <nestedSteps>
+                                                        <item guid="86be5ca3-3fe6-4a17-8d75-a1a6492e3eea" action="eval">
+                                                            <command>
+                                                                <body>lappend tc_uri_list $file_uri</body>
+                                                            </command>
+                                                            <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                                                            <useFieldsInCommand>false</useFieldsInCommand>
+                                                        </item>
+                                                    </nestedSteps>
+                                                    <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                                                    <useFieldsInCommand>false</useFieldsInCommand>
+                                                </item>
+                                            </nestedSteps>
+                                            <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                                            <useFieldsInCommand>false</useFieldsInCommand>
+                                        </item>
+                                    </nestedSteps>
+                                    <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                                    <useFieldsInCommand>false</useFieldsInCommand>
+                                </item>
+                            </nestedSteps>
+                            <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                            <useFieldsInCommand>false</useFieldsInCommand>
+                        </item>
+                    </nestedSteps>
+                    <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                    <useFieldsInCommand>false</useFieldsInCommand>
+                </item>
+                <item guid="8e21cd72-7353-4e10-be1f-c6f13fb9c199" action="return">
+                    <command>
+                        <body>$tc_uri_list</body>
+                    </command>
+                    <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                </item>
+            </steps>
+            <multilineDescription>Return a list of test case URI&apos;s within a given project URI</multilineDescription>
+            <arguments>
+                <item name="uriPath">
+                    <description>URI of project</description>
+                </item>
+            </arguments>
+        </item>
+        <item name="getLibList">
+            <description>Create separate URI lists for QuickCall Libraries, Procedure Libraries and Response Maps</description>
+            <steps>
+                <item guid="42a8efc7-ec4e-4272-951b-44ae00a3b291" action="eval">
+                    <command>
+                        <body>set qc_lib_uri_list {}</body>
+                    </command>
+                    <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                    <useFieldsInCommand>false</useFieldsInCommand>
+                </item>
+                <item guid="924a8842-e57d-4feb-8681-7053583a7ac1" action="eval">
+                    <command>
+                        <body>set proc_lib_uri_list {}</body>
+                    </command>
+                    <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                    <useFieldsInCommand>false</useFieldsInCommand>
+                </item>
+                <item guid="f8857105-9e1d-4999-96ad-4efcb55818e6" action="eval">
+                    <command>
+                        <body>set rm_uri_list {}</body>
+                    </command>
+                    <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                    <useFieldsInCommand>false</useFieldsInCommand>
+                </item>
+                <item guid="2a77e6d4-d77e-44e7-aa37-e5c9243851bc" action="comment">
+                    <command>
+                        <body>Get number of QC libs in project</body>
+                    </command>
+                    <nestedSteps>
+                        <item guid="2af12161-a211-486e-ac74-5c9dac6d88f8" action="foreach">
+                            <command>
+                                <body>uriPath $uriList</body>
+                            </command>
+                            <nestedSteps>
+                                <item guid="a2620ce0-6c77-4e75-a4bb-d3a28f1d0888" action="comment">
+                                    <command>
+                                        <body>if current file is a test case, check if its a QC Lib</body>
+                                    </command>
+                                    <nestedSteps>
+                                        <item guid="fc2dc0af-fc2c-42ef-b4c1-b916910f744e" action="if">
+                                            <command>
+                                                <body>[string match *.fftc $uriPath]</body>
+                                            </command>
+                                            <nestedSteps>
+                                                <item guid="518b8982-40b7-48f1-9f45-01d7a6d12b2e" action="then">
+                                                    <nestedSteps>
+                                                        <item guid="8d2430b6-1064-4d51-82d5-66ae100475c8" action="comment">
+                                                            <command>
+                                                                <body>Determine if this is a QuickCall Library</body>
+                                                            </command>
+                                                            <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                                                            <useFieldsInCommand>false</useFieldsInCommand>
+                                                        </item>
+                                                        <item guid="a2fea8d0-72d6-4719-869e-9028a7f56471" action="eval">
+                                                            <command>
+                                                                <body>set isQc false</body>
+                                                            </command>
+                                                            <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                                                            <useFieldsInCommand>false</useFieldsInCommand>
+                                                        </item>
+                                                        <item guid="bb294759-0e54-48c0-921a-6c838ca5fb35" action="readFile">
+                                                            <command>
+                                                                <body>$uriPath</body>
+                                                            </command>
+                                                            <postProcessing>
+                                                                <analysisRules>
+                                                                    <item>
+                                                                        <extractorInfo extractorType="query">
+                                                                            <extractorProperties type="com.fnfr.svt.mapping.execution.extractors.QueryDataExtractorPropertyGroup">
+                                                                                <query>fn:count(mapped/Xml/testCase/general/sessionClass/@includeTestCase)</query>
+                                                                            </extractorProperties>
+                                                                        </extractorInfo>
+                                                                        <processorInfo ruleType="assert">
+                                                                            <ruleProperties type="com.fnfr.svt.execution.builtin.processors.AssertionPropertyGroup">
+                                                                                <expression>$value == 1</expression>
+                                                                                <actionsWhenFalse>
+                                                                                    <item actionId="Eval">
+                                                                                        <actionProperties type="com.fnfr.svt.execution.builtin.actions.EvalActionPropertyGroup">
+                                                                                            <statement>set isQc false</statement>
+                                                                                        </actionProperties>
+                                                                                    </item>
+                                                                                    <item actionId="SkipRemainingRules">
+                                                                                        <actionProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                                                                                    </item>
+                                                                                </actionsWhenFalse>
+                                                                            </ruleProperties>
+                                                                        </processorInfo>
+                                                                    </item>
+                                                                    <item>
+                                                                        <extractorInfo extractorType="query">
+                                                                            <extractorProperties type="com.fnfr.svt.mapping.execution.extractors.QueryDataExtractorPropertyGroup">
+                                                                                <query>mapped/Xml/testCase/general/sessionClass/@includeTestCase</query>
+                                                                            </extractorProperties>
+                                                                        </extractorInfo>
+                                                                        <processorInfo ruleType="assert">
+                                                                            <ruleProperties type="com.fnfr.svt.execution.builtin.processors.AssertionPropertyGroup">
+                                                                                <expression>$value eq &quot;true&quot;</expression>
+                                                                                <actionsWhenTrue>
+                                                                                    <item actionId="Eval">
+                                                                                        <actionProperties type="com.fnfr.svt.execution.builtin.actions.EvalActionPropertyGroup">
+                                                                                            <statement>set isQc true</statement>
+                                                                                        </actionProperties>
+                                                                                    </item>
+                                                                                </actionsWhenTrue>
+                                                                                <actionsWhenFalse>
+                                                                                    <item actionId="Eval">
+                                                                                        <actionProperties type="com.fnfr.svt.execution.builtin.actions.EvalActionPropertyGroup">
+                                                                                            <statement>set isQc false</statement>
+                                                                                        </actionProperties>
+                                                                                    </item>
+                                                                                </actionsWhenFalse>
+                                                                            </ruleProperties>
+                                                                        </processorInfo>
+                                                                    </item>
+                                                                </analysisRules>
+                                                                <storeResponseAt>xmlResponse</storeResponseAt>
+                                                            </postProcessing>
+                                                            <eventHandlers>
+                                                                <item name="OnInternalError">
+                                                                    <item actionId="FailTest">
+                                                                        <actionProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                                                                    </item>
+                                                                </item>
+                                                            </eventHandlers>
+                                                            <applicationProperties type="com.fnfr.svt.execution.builtin.exec.ReadFilePropertyGroup"/>
+                                                        </item>
+                                                        <item guid="87ee7de6-650e-400d-b2c0-0024ba1f131b" action="if">
+                                                            <command>
+                                                                <body>$isQc == &quot;true&quot;</body>
+                                                            </command>
+                                                            <nestedSteps>
+                                                                <item guid="c662544d-e300-4ed8-b191-03f57a68b53c" action="then">
+                                                                    <nestedSteps>
+                                                                        <item guid="dbb362b0-683c-4fc3-8622-6fc892acf637" action="comment">
+                                                                            <command>
+                                                                                <body>If current file is a QC lib, add it to the QC list </body>
+                                                                            </command>
+                                                                            <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                                                                            <useFieldsInCommand>false</useFieldsInCommand>
+                                                                        </item>
+                                                                        <item guid="808b8e22-b22d-44c4-bfed-5d7bcb6ea1f9" action="eval">
+                                                                            <command>
+                                                                                <body>lappend qc_lib_uri_list $uriPath</body>
+                                                                            </command>
+                                                                            <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                                                                            <useFieldsInCommand>false</useFieldsInCommand>
+                                                                        </item>
+                                                                    </nestedSteps>
+                                                                    <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                                                                    <useFieldsInCommand>false</useFieldsInCommand>
+                                                                </item>
+                                                                <item guid="996a6437-b58c-493a-8336-1558cf817797" action="else">
+                                                                    <nestedSteps>
+                                                                        <item guid="de2dc9ba-fbf6-4781-bdbb-99e69909d12b" action="if">
+                                                                            <command>
+                                                                                <body>[query xmlResponse fn:count(mapped/Xml/testCase/general/isProcedureLibrary)]</body>
+                                                                            </command>
+                                                                            <nestedSteps>
+                                                                                <item guid="dae6081d-b564-41b5-969f-b3b3b58452cd" action="then">
+                                                                                    <nestedSteps>
+                                                                                        <item guid="496689c9-217f-490b-a838-e0b51f9ecbe8" action="eval">
+                                                                                            <command>
+                                                                                                <body>lappend proc_lib_uri_list $uriPath</body>
+                                                                                            </command>
+                                                                                            <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                                                                                            <useFieldsInCommand>false</useFieldsInCommand>
+                                                                                        </item>
+                                                                                    </nestedSteps>
+                                                                                    <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                                                                                    <useFieldsInCommand>false</useFieldsInCommand>
+                                                                                </item>
+                                                                            </nestedSteps>
+                                                                            <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                                                                            <useFieldsInCommand>false</useFieldsInCommand>
+                                                                        </item>
+                                                                    </nestedSteps>
+                                                                    <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                                                                    <useFieldsInCommand>false</useFieldsInCommand>
+                                                                </item>
+                                                            </nestedSteps>
+                                                            <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                                                            <useFieldsInCommand>false</useFieldsInCommand>
+                                                        </item>
+                                                    </nestedSteps>
+                                                    <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                                                    <useFieldsInCommand>false</useFieldsInCommand>
+                                                </item>
+                                                <item guid="1274e498-2b26-4ba5-bf55-23f398c7fd92" action="elseif">
+                                                    <command>
+                                                        <body>[string match *.ffrm $uriPath]</body>
+                                                    </command>
+                                                    <nestedSteps>
+                                                        <item guid="bcc41277-2261-494d-a4fe-d3381be6efd2" action="eval">
+                                                            <command>
+                                                                <body>lappend rm_uri_list $uriPath</body>
+                                                            </command>
+                                                            <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                                                            <useFieldsInCommand>false</useFieldsInCommand>
+                                                        </item>
+                                                    </nestedSteps>
+                                                    <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                                                    <useFieldsInCommand>false</useFieldsInCommand>
+                                                </item>
+                                            </nestedSteps>
+                                            <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                                            <useFieldsInCommand>false</useFieldsInCommand>
+                                        </item>
+                                    </nestedSteps>
+                                    <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                                    <useFieldsInCommand>false</useFieldsInCommand>
+                                </item>
+                            </nestedSteps>
+                            <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                            <useFieldsInCommand>false</useFieldsInCommand>
+                        </item>
+                    </nestedSteps>
+                    <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                    <useFieldsInCommand>false</useFieldsInCommand>
+                </item>
+                <item guid="de7e3af8-65cc-49ba-a944-aa23881fccc3" action="eval">
+                    <command>
+                        <body>gset PROC_LIB_URI_LIST $proc_lib_uri_list</body>
+                    </command>
+                    <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                    <useFieldsInCommand>false</useFieldsInCommand>
+                </item>
+                <item guid="f73ccb97-fea7-4de3-83a0-566e19ee412e" action="eval">
+                    <command>
+                        <body>gset QC_LIB_URI_LIST $qc_lib_uri_list</body>
+                    </command>
+                    <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                    <useFieldsInCommand>false</useFieldsInCommand>
+                </item>
+                <item guid="5e28fab4-9787-4421-8128-5df184272a19" action="eval">
+                    <command>
+                        <body>gset RM_LIB_URI_LIST $rm_uri_list</body>
+                    </command>
+                    <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                    <useFieldsInCommand>false</useFieldsInCommand>
+                </item>
+            </steps>
+            <multilineDescription>Get list of QuickCall Libraries and Procedure Libraries from given list of test case URI&apos;s</multilineDescription>
+            <arguments>
+                <item name="uriList">
+                    <description>List of file URI&apos;s</description>
+                </item>
+            </arguments>
+            <response>{&quot;proc_type&quot;:&quot;value&quot;,&quot;proc_name&quot;:&quot;value&quot;,&quot;headline&quot;:&quot;value&quot;,&quot;description&quot;:&quot;value&quot;,&quot;arguments&quot;:&quot;value&quot;}</response>
+        </item>
+        <item name="createFiles">
+            <description>Create files</description>
+            <steps>
+                <item guid="6f608dff-8121-4994-bacc-f398a1812563" action="eval">
+                    <command>
+                        <body>file mkdir $uriPath/documentation</body>
+                    </command>
+                    <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                    <useFieldsInCommand>false</useFieldsInCommand>
+                </item>
+                <item guid="c53284fb-71bb-4394-9d58-8d8e47024279" action="comment">
+                    <command>
+                        <body>Initial HTML page creation</body>
+                    </command>
+                    <nestedSteps>
+                        <item guid="be422c04-cbc6-4369-9953-c07ba80de488" action="writeFile">
+                            <command>
+                                <body>$uriPath/documentation/index.html &quot;&lt;HTML&gt;&lt;BODY&gt;
 &lt;style&gt;TABLE,TD,TH{border:1px solid black;border-collapse:collapse;}
 th{text-align:left;background-color:AliceBlue;}
 H1,H2{padding-left:15px}
@@ -269,662 +1262,798 @@ H1,H2{padding-left:15px}
 .header2Text{font-size:20px; color:darkblue; font-weight:bold; font-family:arial ;text-align:left; padding-left:5px}
 .header3Text{font-size:18px; color:darkblue; font-weight:bold; font-family:arial ;text-align:left; padding-left:10px}
 &lt;/style&gt;&quot;</body>
-                                                                            </command>
-                                                                            <applicationProperties type="com.fnfr.svt.execution.builtin.exec.WriteFilePropertyGroup">
-                                                                                <appendMode>Overwrite</appendMode>
-                                                                            </applicationProperties>
-                                                                            <useFieldsInCommand>false</useFieldsInCommand>
-                                                                        </item>
-                                                                        <item guid="6ea5649f-450b-4151-a361-a261d7911acb" action="writeFile">
-                                                                            <command>
-                                                                                <body>$uriPath/README.md &quot;&quot;</body>
-                                                                            </command>
-                                                                            <applicationProperties type="com.fnfr.svt.execution.builtin.exec.WriteFilePropertyGroup">
-                                                                                <appendMode>Overwrite</appendMode>
-                                                                            </applicationProperties>
-                                                                            <useFieldsInCommand>false</useFieldsInCommand>
-                                                                        </item>
-                                                                    </nestedSteps>
-                                                                    <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                            </command>
+                            <applicationProperties type="com.fnfr.svt.execution.builtin.exec.WriteFilePropertyGroup">
+                                <appendMode>Overwrite</appendMode>
+                            </applicationProperties>
+                            <useFieldsInCommand>false</useFieldsInCommand>
+                        </item>
+                        <item guid="c51765f3-5843-4500-9fc9-4f406a76c41a" action="writeFile">
+                            <command>
+                                <body>$uriPath/README.md &quot;&quot;</body>
+                            </command>
+                            <applicationProperties type="com.fnfr.svt.execution.builtin.exec.WriteFilePropertyGroup">
+                                <appendMode>Overwrite</appendMode>
+                            </applicationProperties>
+                            <useFieldsInCommand>false</useFieldsInCommand>
+                        </item>
+                    </nestedSteps>
+                    <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                    <useFieldsInCommand>false</useFieldsInCommand>
+                </item>
+                <item guid="6d5ea6fc-875c-4c7a-8fe8-92c1a4263fb8" action="comment">
+                    <command>
+                        <body>Print info from the readme file</body>
+                    </command>
+                    <nestedSteps>
+                        <item guid="8628d1b6-7fc9-44db-90fc-8df9d90ae2b0" action="eval">
+                            <command>
+                                <body>set readmeUri $uriPath/documentation/readme.txt</body>
+                            </command>
+                            <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                            <useFieldsInCommand>false</useFieldsInCommand>
+                        </item>
+                        <item guid="53940af5-3e60-47ed-b99e-3de10b6dbda4" action="if">
+                            <command>
+                                <body>[file exists $readmeUri]</body>
+                            </command>
+                            <nestedSteps>
+                                <item guid="08fb6fe7-616a-413d-bff0-5a2e4395526e" action="then">
+                                    <nestedSteps>
+                                        <item guid="ce353c04-fc06-4472-840c-89afcaaa7eac" action="comment">
+                                            <command>
+                                                <body>new comment</body>
+                                            </command>
+                                            <postProcessing>
+                                                <analysisRules>
+                                                    <item>
+                                                        <extractorInfo extractorType="none">
+                                                            <extractorProperties type="com.fnfr.svt.documents.EmptyExtractorPropertyGroup"/>
+                                                        </extractorInfo>
+                                                        <processorInfo ruleType="message">
+                                                            <ruleProperties type="com.fnfr.svt.execution.builtin.processors.MessageProcessorPropertyGroup" severity="Information">
+                                                                <message>Adding text from: $readmeUri</message>
+                                                            </ruleProperties>
+                                                        </processorInfo>
+                                                    </item>
+                                                </analysisRules>
+                                            </postProcessing>
+                                            <nestedSteps>
+                                                <item guid="d88799ef-d4b9-4e29-9399-9d295808250d" action="readFile">
+                                                    <command>
+                                                        <body>$readmeUri</body>
+                                                    </command>
+                                                    <postProcessing>
+                                                        <storeResponseAt>readme</storeResponseAt>
+                                                        <storeResponseText>true</storeResponseText>
+                                                    </postProcessing>
+                                                    <applicationProperties type="com.fnfr.svt.execution.builtin.exec.ReadFilePropertyGroup"/>
+                                                </item>
+                                            </nestedSteps>
+                                            <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                                            <useFieldsInCommand>false</useFieldsInCommand>
+                                        </item>
+                                    </nestedSteps>
+                                    <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                                    <useFieldsInCommand>false</useFieldsInCommand>
+                                </item>
+                                <item guid="6641af6e-626d-4559-8196-4e6cb8d94f08" action="else">
+                                    <nestedSteps>
+                                        <item guid="7f813c24-cfd7-4c14-8040-20c8bcbb6e9f" action="eval">
+                                            <command>
+                                                <body>set readme $uriPath</body>
+                                            </command>
+                                            <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                                            <useFieldsInCommand>false</useFieldsInCommand>
+                                        </item>
+                                    </nestedSteps>
+                                    <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                                    <useFieldsInCommand>false</useFieldsInCommand>
+                                </item>
+                            </nestedSteps>
+                            <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                            <useFieldsInCommand>false</useFieldsInCommand>
+                        </item>
+                        <item guid="9777d824-1084-4d68-bf49-e503ed97ed35" action="comment">
+                            <command>
+                                <body>Use the first line of the readme as the title</body>
+                            </command>
+                            <nestedSteps>
+                                <item guid="5fcb01e3-b595-4923-a36e-209d32baee1b" action="eval">
+                                    <command>
+                                        <body>set readmeLines [split $readme \\n]</body>
+                                    </command>
+                                    <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                                    <useFieldsInCommand>false</useFieldsInCommand>
+                                </item>
+                                <item guid="90417967-5668-4f41-9ddf-1e1d09a91cc4" action="writeFile" skip="true">
+                                    <command>
+                                        <body>$uriPath/documentation/index.html &quot;&lt;BR&gt;&lt;DIV class=&apos;headerText&apos;&gt;[lindex $readmeLines 0]&lt;/DIV&gt;&quot;</body>
+                                    </command>
+                                    <applicationProperties type="com.fnfr.svt.execution.builtin.exec.WriteFilePropertyGroup"/>
+                                    <useFieldsInCommand>false</useFieldsInCommand>
+                                </item>
+                                <item guid="71ccbfa0-a435-4ee9-8662-fc4ce27639fb" action="writeFile" skip="true">
+                                    <command>
+                                        <body>$uriPath/README.md &quot;# [lindex $readmeLines 0]&quot;</body>
+                                    </command>
+                                    <applicationProperties type="com.fnfr.svt.execution.builtin.exec.WriteFilePropertyGroup"/>
+                                    <useFieldsInCommand>false</useFieldsInCommand>
+                                </item>
+                                <item guid="b5acda83-214f-499d-9bb4-85c14e5c6142" action="eval" skip="true">
+                                    <command>
+                                        <body>set readmeLines [lreplace $readmeLines 0 0]</body>
+                                    </command>
+                                    <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                                    <useFieldsInCommand>false</useFieldsInCommand>
+                                </item>
+                            </nestedSteps>
+                            <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                            <useFieldsInCommand>false</useFieldsInCommand>
+                        </item>
+                        <item guid="52b22888-b9e4-4ce7-90ab-1462019b5807" action="comment">
+                            <command>
+                                <body>Print the remaining lines as body text</body>
+                            </command>
+                            <nestedSteps>
+                                <item guid="780ca95f-20ab-48fb-a3b4-aababadec47e" action="foreach">
+                                    <command>
+                                        <body>line $readmeLines</body>
+                                    </command>
+                                    <nestedSteps>
+                                        <item guid="83ef95e3-0af3-4af9-93ab-c6fbef43b13a" action="if">
+                                            <command>
+                                                <body>$line != &quot;&quot;</body>
+                                            </command>
+                                            <nestedSteps>
+                                                <item guid="3648f75f-fd92-4417-9f50-aa4f89fee0b0" action="then">
+                                                    <nestedSteps>
+                                                        <item guid="2429f84b-ecf2-4bc3-96ec-ddbcde3e5f51" action="writeFile">
+                                                            <command>
+                                                                <body>$uriPath/documentation/index.html &quot;&lt;DIV class=&apos;normalText&apos;&gt;$line&lt;/DIV&gt;&quot;</body>
+                                                            </command>
+                                                            <applicationProperties type="com.fnfr.svt.execution.builtin.exec.WriteFilePropertyGroup"/>
+                                                            <useFieldsInCommand>false</useFieldsInCommand>
+                                                        </item>
+                                                        <item guid="9b8c5a6e-7e56-42db-95f5-1ae48ef2cac6" action="writeFile" skip="true">
+                                                            <command>
+                                                                <body>$uriPath/documentation/index.html &quot;&lt;DIV style=&apos;margin-left:30px; &apos; class=&apos;normalText&apos;&gt;$line&lt;/DIV&gt;&quot;</body>
+                                                            </command>
+                                                            <applicationProperties type="com.fnfr.svt.execution.builtin.exec.WriteFilePropertyGroup"/>
+                                                            <useFieldsInCommand>false</useFieldsInCommand>
+                                                        </item>
+                                                        <item guid="4bd2073d-9363-442b-98cf-bd208d36c517" action="writeFile">
+                                                            <command>
+                                                                <body>$uriPath/README.md &quot;$line\\n&quot;</body>
+                                                            </command>
+                                                            <applicationProperties type="com.fnfr.svt.execution.builtin.exec.WriteFilePropertyGroup"/>
+                                                            <useFieldsInCommand>false</useFieldsInCommand>
+                                                        </item>
+                                                    </nestedSteps>
+                                                    <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                                                    <useFieldsInCommand>false</useFieldsInCommand>
+                                                </item>
+                                                <item guid="7aa327ba-81c5-4ec5-b3b4-ec193e7791bc" action="else">
+                                                    <nestedSteps>
+                                                        <item guid="1944cbc5-ee25-445c-8948-4924be49c9a3" action="writeFile">
+                                                            <command>
+                                                                <body>$uriPath/documentation/index.html &quot;&lt;DIV style=&apos;margin-left:30px; &apos; class=&apos;normalText&apos;&gt;&lt;BR&gt;&lt;/DIV&gt;&quot;</body>
+                                                            </command>
+                                                            <applicationProperties type="com.fnfr.svt.execution.builtin.exec.WriteFilePropertyGroup"/>
+                                                            <useFieldsInCommand>false</useFieldsInCommand>
+                                                        </item>
+                                                        <item guid="e1c010de-41fe-405e-b8e8-a60d3c59f53c" action="writeFile">
+                                                            <command>
+                                                                <body>$uriPath/README.md &quot;\\n&quot;</body>
+                                                            </command>
+                                                            <applicationProperties type="com.fnfr.svt.execution.builtin.exec.WriteFilePropertyGroup"/>
+                                                            <useFieldsInCommand>false</useFieldsInCommand>
+                                                        </item>
+                                                    </nestedSteps>
+                                                    <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                                                    <useFieldsInCommand>false</useFieldsInCommand>
+                                                </item>
+                                            </nestedSteps>
+                                            <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                                            <useFieldsInCommand>false</useFieldsInCommand>
+                                        </item>
+                                    </nestedSteps>
+                                    <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                                    <useFieldsInCommand>false</useFieldsInCommand>
+                                </item>
+                            </nestedSteps>
+                            <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                            <useFieldsInCommand>false</useFieldsInCommand>
+                        </item>
+                    </nestedSteps>
+                    <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                    <useFieldsInCommand>false</useFieldsInCommand>
+                </item>
+            </steps>
+            <multilineDescription>Create HTML and MD files</multilineDescription>
+            <arguments>
+                <item name="uriPath">
+                    <description>URI to project</description>
+                    <isMandatory>true</isMandatory>
+                </item>
+            </arguments>
+        </item>
+        <item name="writeLibrariesFound">
+            <description>Get QuickCall and Procedure libraries</description>
+            <steps>
+                <item guid="49273e8c-50e3-4fb1-810c-f2d6529a64b3" action="comment">
+                    <command>
+                        <body>Print number of QuickCall Libraries</body>
+                    </command>
+                    <nestedSteps>
+                        <item guid="bf3f450d-c019-444b-bd8f-1fdcf3dfafb7" action="if">
+                            <command>
+                                <body>[llength [gget QC_LIB_URI_LIST]] == 1</body>
+                            </command>
+                            <nestedSteps>
+                                <item guid="ecefdf3e-9377-4dc4-87aa-7401e43b01df" action="then">
+                                    <nestedSteps>
+                                        <item guid="f6588811-b0bc-4b99-b76e-b4fdb5d3fbc3" action="comment">
+                                            <command>
+                                                <body>Write out &quot;library&quot; if one QC lib in list</body>
+                                            </command>
+                                            <nestedSteps>
+                                                <item guid="dc542850-b1cd-4956-8b41-30efc41e4824" action="writeFile">
+                                                    <command>
+                                                        <body>$uriPath/documentation/index.html &quot;&lt;BR&gt;&lt;DIV class=&apos;normalText&apos;&gt;[llength [gget QC_LIB_URI_LIST]] QuickCall Library in $uriPath&lt;/DIV&gt;&quot;</body>
+                                                    </command>
+                                                    <applicationProperties type="com.fnfr.svt.execution.builtin.exec.WriteFilePropertyGroup"/>
+                                                    <useFieldsInCommand>false</useFieldsInCommand>
+                                                </item>
+                                                <item guid="10259408-618b-413d-81e2-f1e2cf96e468" action="writeFile">
+                                                    <command>
+                                                        <body>$uriPath/README.md &quot;[llength [gget QC_LIB_URI_LIST]] QuickCall Library in $uriPath&quot;</body>
+                                                    </command>
+                                                    <applicationProperties type="com.fnfr.svt.execution.builtin.exec.WriteFilePropertyGroup"/>
+                                                    <useFieldsInCommand>false</useFieldsInCommand>
+                                                </item>
+                                            </nestedSteps>
+                                            <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                                            <useFieldsInCommand>false</useFieldsInCommand>
+                                        </item>
+                                    </nestedSteps>
+                                    <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                                    <useFieldsInCommand>false</useFieldsInCommand>
+                                </item>
+                                <item guid="0ca89d1d-b095-4807-b2a6-edee6ec55279" action="elseif">
+                                    <command>
+                                        <body>[llength [gget QC_LIB_URI_LIST]] &gt; 1</body>
+                                    </command>
+                                    <nestedSteps>
+                                        <item guid="ea0dc8b6-9055-4a27-ae58-d6b1df7c2936" action="comment">
+                                            <command>
+                                                <body>Write out &quot;libraries&quot; if more than one QC lib in list</body>
+                                            </command>
+                                            <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                                            <useFieldsInCommand>false</useFieldsInCommand>
+                                        </item>
+                                        <item guid="719acb37-cad8-4fb8-8cab-d1ad9c8e8c1a" action="writeFile">
+                                            <command>
+                                                <body>$uriPath/documentation/index.html &quot;&lt;BR&gt;&lt;DIV class=&apos;normalText&apos;&gt;[llength [gget QC_LIB_URI_LIST]] QuickCall Libraries in $uriPath&lt;/DIV&gt;&quot;</body>
+                                            </command>
+                                            <applicationProperties type="com.fnfr.svt.execution.builtin.exec.WriteFilePropertyGroup"/>
+                                            <useFieldsInCommand>false</useFieldsInCommand>
+                                        </item>
+                                        <item guid="6aa7b766-d228-42fa-84f7-94255e6459ba" action="writeFile">
+                                            <command>
+                                                <body>$uriPath/README.md &quot;[llength [gget QC_LIB_URI_LIST]] QuickCall Libraries in $uriPath&quot;</body>
+                                            </command>
+                                            <applicationProperties type="com.fnfr.svt.execution.builtin.exec.WriteFilePropertyGroup"/>
+                                            <useFieldsInCommand>false</useFieldsInCommand>
+                                        </item>
+                                    </nestedSteps>
+                                    <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                                    <useFieldsInCommand>false</useFieldsInCommand>
+                                </item>
+                            </nestedSteps>
+                            <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                            <useFieldsInCommand>false</useFieldsInCommand>
+                        </item>
+                    </nestedSteps>
+                    <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                    <useFieldsInCommand>false</useFieldsInCommand>
+                </item>
+                <item guid="a9f0a445-bf70-4511-bc2a-6abdb0fd5d10" action="comment">
+                    <command>
+                        <body>Print number of Procedure Libraries</body>
+                    </command>
+                    <nestedSteps>
+                        <item guid="b6862590-e42e-48bc-b132-3a758b8c711f" action="if">
+                            <command>
+                                <body>[llength [gget PROC_LIB_URI_LIST]] == 1</body>
+                            </command>
+                            <nestedSteps>
+                                <item guid="a34c4cfb-9089-4864-abfa-cedea6daf5f7" action="then">
+                                    <nestedSteps>
+                                        <item guid="e7dd9257-1bca-420b-b97b-4a9913a394c1" action="comment">
+                                            <command>
+                                                <body>Write out &quot;library&quot; if one Proc lib in list</body>
+                                            </command>
+                                            <nestedSteps>
+                                                <item guid="5ff41139-5c1e-4b97-9d98-3976cfb21cfd" action="writeFile">
+                                                    <command>
+                                                        <body>$uriPath/documentation/index.html &quot;&lt;BR&gt;&lt;DIV class=&apos;normalText&apos;&gt;[llength [gget PROC_LIB_URI_LIST]] Procedure Library in $uriPath&lt;/DIV&gt;&quot;</body>
+                                                    </command>
+                                                    <applicationProperties type="com.fnfr.svt.execution.builtin.exec.WriteFilePropertyGroup"/>
+                                                    <useFieldsInCommand>false</useFieldsInCommand>
+                                                </item>
+                                                <item guid="65b70ac3-19c8-4fec-b04d-45fbc2364586" action="writeFile">
+                                                    <command>
+                                                        <body>$uriPath/README.md &quot;[llength [gget PROC_LIB_URI_LIST]] Procedure Library in $uriPath&quot;</body>
+                                                    </command>
+                                                    <applicationProperties type="com.fnfr.svt.execution.builtin.exec.WriteFilePropertyGroup"/>
+                                                    <useFieldsInCommand>false</useFieldsInCommand>
+                                                </item>
+                                            </nestedSteps>
+                                            <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                                            <useFieldsInCommand>false</useFieldsInCommand>
+                                        </item>
+                                    </nestedSteps>
+                                    <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                                    <useFieldsInCommand>false</useFieldsInCommand>
+                                </item>
+                                <item guid="03917106-aaf2-4eb9-bfea-f2ea87d20838" action="elseif">
+                                    <command>
+                                        <body>[llength [gget PROC_LIB_URI_LIST]] &gt; 1</body>
+                                    </command>
+                                    <nestedSteps>
+                                        <item guid="b3138f4a-28c0-45fe-ad9d-cd1ee51b44ad" action="comment">
+                                            <command>
+                                                <body>Write out &quot;libraries&quot; if more than one Proc lib in list</body>
+                                            </command>
+                                            <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                                            <useFieldsInCommand>false</useFieldsInCommand>
+                                        </item>
+                                        <item guid="ddc3ff64-0b32-42ef-926d-bd07cef2fd6d" action="writeFile">
+                                            <command>
+                                                <body>$uriPath/documentation/index.html &quot;&lt;BR&gt;&lt;DIV class=&apos;normalText&apos;&gt;[llength [gget PROC_LIB_URI_LIST]] Procedure Libraries in $uriPath&lt;/DIV&gt;&quot;</body>
+                                            </command>
+                                            <applicationProperties type="com.fnfr.svt.execution.builtin.exec.WriteFilePropertyGroup"/>
+                                            <useFieldsInCommand>false</useFieldsInCommand>
+                                        </item>
+                                        <item guid="a33111bc-8160-40a4-be9d-1ad931a0a735" action="writeFile">
+                                            <command>
+                                                <body>$uriPath/README.md &quot;[llength [gget PROC_LIB_URI_LIST]] Procedure Libraries in $uriPath&quot;</body>
+                                            </command>
+                                            <applicationProperties type="com.fnfr.svt.execution.builtin.exec.WriteFilePropertyGroup"/>
+                                            <useFieldsInCommand>false</useFieldsInCommand>
+                                        </item>
+                                    </nestedSteps>
+                                    <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                                    <useFieldsInCommand>false</useFieldsInCommand>
+                                </item>
+                            </nestedSteps>
+                            <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                            <useFieldsInCommand>false</useFieldsInCommand>
+                        </item>
+                    </nestedSteps>
+                    <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                    <useFieldsInCommand>false</useFieldsInCommand>
+                </item>
+                <item guid="817469c7-097c-4686-8949-ab4bfae2027a" action="comment">
+                    <command>
+                        <body>Print number of Response Map Libraries</body>
+                    </command>
+                    <nestedSteps>
+                        <item guid="adb37124-3ef5-47f1-8595-6bc543fad3ee" action="if">
+                            <command>
+                                <body>[param includeResponseMaps] == &quot;true&quot;</body>
+                            </command>
+                            <nestedSteps>
+                                <item guid="b2c5c974-1172-46d5-aab0-c9e6b60ccecb" action="then">
+                                    <nestedSteps>
+                                        <item guid="bc6efe2c-bdef-462f-9c9d-4dbe80019774" action="if">
+                                            <command>
+                                                <body>[llength [gget RM_LIB_URI_LIST]] == 1</body>
+                                            </command>
+                                            <nestedSteps>
+                                                <item guid="57b20e0f-1727-49ca-9fab-60bb7745a9e6" action="then">
+                                                    <nestedSteps>
+                                                        <item guid="91a8d612-1f03-46be-8de4-5abad9ce6bd0" action="comment">
+                                                            <command>
+                                                                <body>Write out &quot;Map&quot; if one Proc lib in list</body>
+                                                            </command>
+                                                            <nestedSteps>
+                                                                <item guid="1533fd66-a15c-4015-8500-a89f8416b7b0" action="writeFile">
+                                                                    <command>
+                                                                        <body>$uriPath/documentation/index.html &quot;&lt;BR&gt;&lt;DIV class=&apos;normalText&apos;&gt;[llength [gget RM_LIB_URI_LIST]] Response Map in $uriPath&lt;/DIV&gt;&quot;</body>
+                                                                    </command>
+                                                                    <applicationProperties type="com.fnfr.svt.execution.builtin.exec.WriteFilePropertyGroup"/>
                                                                     <useFieldsInCommand>false</useFieldsInCommand>
                                                                 </item>
-                                                                <item guid="72eed5a5-15b3-4eb6-ac9e-8146e72c7cde" action="comment">
+                                                                <item guid="2c76e6ce-969b-4144-b21a-b0825bb03172" action="writeFile">
                                                                     <command>
-                                                                        <body>Print info from the readme file and find all the QC libs</body>
+                                                                        <body>$uriPath/README.md &quot;[llength [gget RM_LIB_URI_LIST]] Response Map in $uriPath&quot;</body>
                                                                     </command>
-                                                                    <nestedSteps>
-                                                                        <item guid="a7126fc5-8b5f-4e3d-a72c-c88c9854661c" action="eval">
-                                                                            <command>
-                                                                                <body>set readmeFile $uriPath/documentation/readme.txt</body>
-                                                                            </command>
-                                                                            <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
-                                                                            <useFieldsInCommand>false</useFieldsInCommand>
-                                                                        </item>
-                                                                        <item guid="426a51ab-6358-4d34-8db0-d603e28a979a" action="if">
-                                                                            <command>
-                                                                                <body>[file exists $readmeFile]</body>
-                                                                            </command>
-                                                                            <nestedSteps>
-                                                                                <item guid="b8314d93-1a2d-4b54-baa1-14dd77cad13a" action="then">
-                                                                                    <nestedSteps>
-                                                                                        <item guid="450134a1-c87f-4d88-ad5c-b3c0d75383a3" action="readFile">
-                                                                                            <command>
-                                                                                                <body>$readmeFile</body>
-                                                                                            </command>
-                                                                                            <postProcessing>
-                                                                                                <storeResponseAt>readme</storeResponseAt>
-                                                                                                <storeResponseText>true</storeResponseText>
-                                                                                            </postProcessing>
-                                                                                            <applicationProperties type="com.fnfr.svt.execution.builtin.exec.ReadFilePropertyGroup"/>
-                                                                                        </item>
-                                                                                    </nestedSteps>
-                                                                                    <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
-                                                                                    <useFieldsInCommand>false</useFieldsInCommand>
-                                                                                </item>
-                                                                                <item guid="bb202219-930e-4711-b491-b1a900e13cf0" action="else">
-                                                                                    <nestedSteps>
-                                                                                        <item guid="c9f978b5-5342-4396-9914-5b20f30d097e" action="eval">
-                                                                                            <command>
-                                                                                                <body>set readme $uriPath</body>
-                                                                                            </command>
-                                                                                            <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
-                                                                                            <useFieldsInCommand>false</useFieldsInCommand>
-                                                                                        </item>
-                                                                                    </nestedSteps>
-                                                                                    <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
-                                                                                    <useFieldsInCommand>false</useFieldsInCommand>
-                                                                                </item>
-                                                                            </nestedSteps>
-                                                                            <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
-                                                                            <useFieldsInCommand>false</useFieldsInCommand>
-                                                                        </item>
-                                                                        <item guid="13cabfdd-1e8a-4914-9876-91f4da654c75" action="comment">
-                                                                            <command>
-                                                                                <body>Use the first line of the readme as the title</body>
-                                                                            </command>
-                                                                            <nestedSteps>
-                                                                                <item guid="5eef36ec-246e-4a58-a343-d7f02826b606" action="eval">
-                                                                                    <command>
-                                                                                        <body>set readmeLines [split $readme \\n]</body>
-                                                                                    </command>
-                                                                                    <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
-                                                                                    <useFieldsInCommand>false</useFieldsInCommand>
-                                                                                </item>
-                                                                                <item guid="f4730fb1-8f87-4324-8ab7-02d94082842b" action="writeFile">
-                                                                                    <command>
-                                                                                        <body>$uriPath/documentation/index.html &quot;&lt;BR&gt;&lt;DIV class=&apos;headerText&apos;&gt;[lindex $readmeLines 0]&lt;/DIV&gt;&quot;</body>
-                                                                                    </command>
-                                                                                    <applicationProperties type="com.fnfr.svt.execution.builtin.exec.WriteFilePropertyGroup"/>
-                                                                                    <useFieldsInCommand>false</useFieldsInCommand>
-                                                                                </item>
-                                                                                <item guid="f2cf7a13-bde4-4369-a201-410d264b1e50" action="writeFile">
-                                                                                    <command>
-                                                                                        <body>$uriPath/README.md &quot;# [lindex $readmeLines 0]&quot;</body>
-                                                                                    </command>
-                                                                                    <applicationProperties type="com.fnfr.svt.execution.builtin.exec.WriteFilePropertyGroup"/>
-                                                                                    <useFieldsInCommand>false</useFieldsInCommand>
-                                                                                </item>
-                                                                                <item guid="42ff1e79-6fcc-4a70-aa2b-e33138d2f5cb" action="eval">
-                                                                                    <command>
-                                                                                        <body>set readmeLines [lreplace $readmeLines 0 0]</body>
-                                                                                    </command>
-                                                                                    <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
-                                                                                    <useFieldsInCommand>false</useFieldsInCommand>
-                                                                                </item>
-                                                                            </nestedSteps>
-                                                                            <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
-                                                                            <useFieldsInCommand>false</useFieldsInCommand>
-                                                                        </item>
-                                                                        <item guid="744fd03c-71a5-4229-ac95-8b3125d61e68" action="comment">
-                                                                            <command>
-                                                                                <body>Print the remaining lines as body text</body>
-                                                                            </command>
-                                                                            <nestedSteps>
-                                                                                <item guid="7b548a31-23a4-4310-b99d-c7e1208e8e22" action="foreach">
-                                                                                    <command>
-                                                                                        <body>line $readmeLines</body>
-                                                                                    </command>
-                                                                                    <nestedSteps>
-                                                                                        <item guid="df948904-3235-449b-a22f-af0153e8a4ea" action="if">
-                                                                                            <command>
-                                                                                                <body>$line != &quot;&quot;</body>
-                                                                                            </command>
-                                                                                            <nestedSteps>
-                                                                                                <item guid="78e20a26-ecc5-454c-b125-53d3f3bd6d38" action="then">
-                                                                                                    <nestedSteps>
-                                                                                                        <item guid="7a02fdad-9e26-4918-aaa2-cde58d137138" action="writeFile">
-                                                                                                            <command>
-                                                                                                                <body>$uriPath/documentation/index.html &quot;&lt;DIV style=&apos;margin-left:30px; &apos; class=&apos;normalText&apos;&gt;$line&lt;/DIV&gt;&quot;</body>
-                                                                                                            </command>
-                                                                                                            <applicationProperties type="com.fnfr.svt.execution.builtin.exec.WriteFilePropertyGroup"/>
-                                                                                                            <useFieldsInCommand>false</useFieldsInCommand>
-                                                                                                        </item>
-                                                                                                        <item guid="c26daa47-abdd-4d75-84cf-de4cf7d4c7cc" action="writeFile">
-                                                                                                            <command>
-                                                                                                                <body>$uriPath/README.md &quot;$line\\n&quot;</body>
-                                                                                                            </command>
-                                                                                                            <applicationProperties type="com.fnfr.svt.execution.builtin.exec.WriteFilePropertyGroup"/>
-                                                                                                            <useFieldsInCommand>false</useFieldsInCommand>
-                                                                                                        </item>
-                                                                                                    </nestedSteps>
-                                                                                                    <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
-                                                                                                    <useFieldsInCommand>false</useFieldsInCommand>
-                                                                                                </item>
-                                                                                                <item guid="a10e8e07-c62a-4e90-a029-98ad64f54f69" action="else">
-                                                                                                    <nestedSteps>
-                                                                                                        <item guid="5772746a-b4e1-4100-bada-45c054f53e4e" action="writeFile">
-                                                                                                            <command>
-                                                                                                                <body>$uriPath/documentation/index.html &quot;&lt;DIV style=&apos;margin-left:30px; &apos; class=&apos;normalText&apos;&gt;&lt;BR&gt;&lt;/DIV&gt;&quot;</body>
-                                                                                                            </command>
-                                                                                                            <applicationProperties type="com.fnfr.svt.execution.builtin.exec.WriteFilePropertyGroup"/>
-                                                                                                            <useFieldsInCommand>false</useFieldsInCommand>
-                                                                                                        </item>
-                                                                                                        <item guid="d645d76e-7f82-432a-9497-a3fbe460c589" action="writeFile">
-                                                                                                            <command>
-                                                                                                                <body>$uriPath/README.md &quot;\\n&quot;</body>
-                                                                                                            </command>
-                                                                                                            <applicationProperties type="com.fnfr.svt.execution.builtin.exec.WriteFilePropertyGroup"/>
-                                                                                                            <useFieldsInCommand>false</useFieldsInCommand>
-                                                                                                        </item>
-                                                                                                    </nestedSteps>
-                                                                                                    <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
-                                                                                                    <useFieldsInCommand>false</useFieldsInCommand>
-                                                                                                </item>
-                                                                                            </nestedSteps>
-                                                                                            <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
-                                                                                            <useFieldsInCommand>false</useFieldsInCommand>
-                                                                                        </item>
-                                                                                    </nestedSteps>
-                                                                                    <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
-                                                                                    <useFieldsInCommand>false</useFieldsInCommand>
-                                                                                </item>
-                                                                            </nestedSteps>
-                                                                            <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
-                                                                            <useFieldsInCommand>false</useFieldsInCommand>
-                                                                        </item>
-                                                                        <item guid="e47cd8d1-3b5f-4610-aa83-ca86e65e9733" action="comment">
-                                                                            <command>
-                                                                                <body>Get number of QC libs in project</body>
-                                                                            </command>
-                                                                            <nestedSteps>
-                                                                                <item guid="de2b6753-121e-428f-9808-54b22c5696d3" action="foreach">
-                                                                                    <command>
-                                                                                        <body>testCase [response fileList]</body>
-                                                                                    </command>
-                                                                                    <nestedSteps>
-                                                                                        <item guid="fe18cc3d-81bc-4d09-9b7a-533b0f9cdbe3" action="comment">
-                                                                                            <command>
-                                                                                                <body>if current file is a test case, check if its a QC Lib</body>
-                                                                                            </command>
-                                                                                            <nestedSteps>
-                                                                                                <item guid="3b2a264e-4e86-4c08-90cc-dba1fbaf89d3" action="if">
-                                                                                                    <command>
-                                                                                                        <body>[string match *.fftc $testCase]</body>
-                                                                                                    </command>
-                                                                                                    <nestedSteps>
-                                                                                                        <item guid="3f25fa4e-d02e-4b13-b9b7-044b4062083f" action="then">
-                                                                                                            <nestedSteps>
-                                                                                                                <item guid="63785d38-3d35-431e-a9f2-73364823dd66" action="comment">
-                                                                                                                    <command>
-                                                                                                                        <body>This is a test case</body>
-                                                                                                                    </command>
-                                                                                                                    <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
-                                                                                                                    <useFieldsInCommand>false</useFieldsInCommand>
-                                                                                                                </item>
-                                                                                                                <item guid="72b8bf2c-98af-414d-bfc2-f17c770b14d1" action="readFile">
-                                                                                                                    <command>
-                                                                                                                        <body>$testCase</body>
-                                                                                                                    </command>
-                                                                                                                    <postProcessing>
-                                                                                                                        <analysisRules>
-                                                                                                                            <item>
-                                                                                                                                <extractorInfo extractorType="query">
-                                                                                                                                    <extractorProperties type="com.fnfr.svt.mapping.execution.extractors.QueryDataExtractorPropertyGroup">
-                                                                                                                                        <query>fn:count(mapped/Xml/testCase/general/sessionClass/@includeTestCase)</query>
-                                                                                                                                    </extractorProperties>
-                                                                                                                                </extractorInfo>
-                                                                                                                                <processorInfo ruleType="assert">
-                                                                                                                                    <ruleProperties type="com.fnfr.svt.execution.builtin.processors.AssertionPropertyGroup">
-                                                                                                                                        <expression>$value == 1</expression>
-                                                                                                                                        <actionsWhenFalse>
-                                                                                                                                            <item actionId="Eval">
-                                                                                                                                                <actionProperties type="com.fnfr.svt.execution.builtin.actions.EvalActionPropertyGroup">
-                                                                                                                                                    <statement>set isQc false</statement>
-                                                                                                                                                </actionProperties>
-                                                                                                                                            </item>
-                                                                                                                                            <item actionId="SkipRemainingRules">
-                                                                                                                                                <actionProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
-                                                                                                                                            </item>
-                                                                                                                                        </actionsWhenFalse>
-                                                                                                                                    </ruleProperties>
-                                                                                                                                </processorInfo>
-                                                                                                                            </item>
-                                                                                                                            <item>
-                                                                                                                                <extractorInfo extractorType="query">
-                                                                                                                                    <extractorProperties type="com.fnfr.svt.mapping.execution.extractors.QueryDataExtractorPropertyGroup">
-                                                                                                                                        <query>mapped/Xml/testCase/general/sessionClass/@includeTestCase</query>
-                                                                                                                                    </extractorProperties>
-                                                                                                                                </extractorInfo>
-                                                                                                                                <processorInfo ruleType="assert">
-                                                                                                                                    <ruleProperties type="com.fnfr.svt.execution.builtin.processors.AssertionPropertyGroup">
-                                                                                                                                        <expression>$value eq &quot;true&quot;</expression>
-                                                                                                                                        <actionsWhenTrue>
-                                                                                                                                            <item actionId="Eval">
-                                                                                                                                                <actionProperties type="com.fnfr.svt.execution.builtin.actions.EvalActionPropertyGroup">
-                                                                                                                                                    <statement>set isQc true</statement>
-                                                                                                                                                </actionProperties>
-                                                                                                                                            </item>
-                                                                                                                                        </actionsWhenTrue>
-                                                                                                                                        <actionsWhenFalse>
-                                                                                                                                            <item actionId="Eval">
-                                                                                                                                                <actionProperties type="com.fnfr.svt.execution.builtin.actions.EvalActionPropertyGroup">
-                                                                                                                                                    <statement>set isQc false</statement>
-                                                                                                                                                </actionProperties>
-                                                                                                                                            </item>
-                                                                                                                                        </actionsWhenFalse>
-                                                                                                                                    </ruleProperties>
-                                                                                                                                </processorInfo>
-                                                                                                                            </item>
-                                                                                                                        </analysisRules>
-                                                                                                                        <storeResponseAt>xmlResponse</storeResponseAt>
-                                                                                                                    </postProcessing>
-                                                                                                                    <eventHandlers>
-                                                                                                                        <item name="OnInternalError">
-                                                                                                                            <item actionId="FailTest">
-                                                                                                                                <actionProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
-                                                                                                                            </item>
-                                                                                                                        </item>
-                                                                                                                    </eventHandlers>
-                                                                                                                    <applicationProperties type="com.fnfr.svt.execution.builtin.exec.ReadFilePropertyGroup"/>
-                                                                                                                </item>
-                                                                                                                <item guid="26588c9c-9a64-4e17-9603-8096536942ff" action="if">
-                                                                                                                    <command>
-                                                                                                                        <body>$isQc == &quot;true&quot;</body>
-                                                                                                                    </command>
-                                                                                                                    <nestedSteps>
-                                                                                                                        <item guid="495eb009-941f-4b76-b70e-1c275b187466" action="then">
-                                                                                                                            <nestedSteps>
-                                                                                                                                <item guid="2078a403-0c18-4227-a5c1-1247ec8f3234" action="comment">
-                                                                                                                                    <command>
-                                                                                                                                        <body>If current file is a QC lib, add it to the QC list </body>
-                                                                                                                                    </command>
-                                                                                                                                    <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
-                                                                                                                                    <useFieldsInCommand>false</useFieldsInCommand>
-                                                                                                                                </item>
-                                                                                                                                <item guid="d5aba453-4509-469d-bd80-6dd141b1f2cc" action="eval">
-                                                                                                                                    <command>
-                                                                                                                                        <body>lappend qcList $testCase</body>
-                                                                                                                                    </command>
-                                                                                                                                    <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
-                                                                                                                                    <useFieldsInCommand>false</useFieldsInCommand>
-                                                                                                                                </item>
-                                                                                                                            </nestedSteps>
-                                                                                                                            <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
-                                                                                                                            <useFieldsInCommand>false</useFieldsInCommand>
-                                                                                                                        </item>
-                                                                                                                    </nestedSteps>
-                                                                                                                    <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
-                                                                                                                    <useFieldsInCommand>false</useFieldsInCommand>
-                                                                                                                </item>
-                                                                                                            </nestedSteps>
-                                                                                                            <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
-                                                                                                            <useFieldsInCommand>false</useFieldsInCommand>
-                                                                                                        </item>
-                                                                                                    </nestedSteps>
-                                                                                                    <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
-                                                                                                    <useFieldsInCommand>false</useFieldsInCommand>
-                                                                                                </item>
-                                                                                            </nestedSteps>
-                                                                                            <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
-                                                                                            <useFieldsInCommand>false</useFieldsInCommand>
-                                                                                        </item>
-                                                                                    </nestedSteps>
-                                                                                    <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
-                                                                                    <useFieldsInCommand>false</useFieldsInCommand>
-                                                                                </item>
-                                                                            </nestedSteps>
-                                                                            <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
-                                                                            <useFieldsInCommand>false</useFieldsInCommand>
-                                                                        </item>
-                                                                        <item guid="beb45d0b-5de5-4a4e-a4e1-8cc389bafa0d" action="comment">
-                                                                            <command>
-                                                                                <body>Print number of QC Libs</body>
-                                                                            </command>
-                                                                            <nestedSteps>
-                                                                                <item guid="6a6d6551-a821-40d9-b24b-0797d287ebe4" action="if">
-                                                                                    <command>
-                                                                                        <body>[llength $qcList] == 1</body>
-                                                                                    </command>
-                                                                                    <nestedSteps>
-                                                                                        <item guid="d34c8b31-3d0c-49d9-ab07-80cc6f225c9c" action="then">
-                                                                                            <nestedSteps>
-                                                                                                <item guid="886c54f9-2b3f-458e-a6c1-d38cb20ad4cb" action="comment">
-                                                                                                    <command>
-                                                                                                        <body>Write out &quot;library&quot; if one QC lib in list</body>
-                                                                                                    </command>
-                                                                                                    <nestedSteps>
-                                                                                                        <item guid="3de1c654-3e30-420b-a5f8-b5e4b693ae53" action="writeFile">
-                                                                                                            <command>
-                                                                                                                <body>$uriPath/documentation/index.html &quot;&lt;BR&gt;&lt;DIV class=&apos;header2Text&apos;&gt;[llength $qcList] QuickCall Library in $uriPath:&lt;/DIV&gt;&quot;</body>
-                                                                                                            </command>
-                                                                                                            <applicationProperties type="com.fnfr.svt.execution.builtin.exec.WriteFilePropertyGroup"/>
-                                                                                                            <useFieldsInCommand>false</useFieldsInCommand>
-                                                                                                        </item>
-                                                                                                        <item guid="2af62dae-a13c-427a-a652-753bd3b6a5c5" action="writeFile">
-                                                                                                            <command>
-                                                                                                                <body>$uriPath/README.md &quot;[llength $qcList] QuickCall Library in $uriPath:&quot;</body>
-                                                                                                            </command>
-                                                                                                            <applicationProperties type="com.fnfr.svt.execution.builtin.exec.WriteFilePropertyGroup"/>
-                                                                                                            <useFieldsInCommand>false</useFieldsInCommand>
-                                                                                                        </item>
-                                                                                                    </nestedSteps>
-                                                                                                    <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
-                                                                                                    <useFieldsInCommand>false</useFieldsInCommand>
-                                                                                                </item>
-                                                                                            </nestedSteps>
-                                                                                            <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
-                                                                                            <useFieldsInCommand>false</useFieldsInCommand>
-                                                                                        </item>
-                                                                                        <item guid="7acec608-1b76-4652-baf3-7644abb593ae" action="elseif">
-                                                                                            <command>
-                                                                                                <body>[llength $qcList] &gt; 1</body>
-                                                                                            </command>
-                                                                                            <nestedSteps>
-                                                                                                <item guid="89e1504a-0516-46ca-b7e8-e2e9089ca6ed" action="comment">
-                                                                                                    <command>
-                                                                                                        <body>Write out &quot;libraries&quot; if zero or more than one QC lib in list</body>
-                                                                                                    </command>
-                                                                                                    <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
-                                                                                                    <useFieldsInCommand>false</useFieldsInCommand>
-                                                                                                </item>
-                                                                                                <item guid="3b4f2f6f-cf7e-445c-870b-e0573bab5e95" action="writeFile">
-                                                                                                    <command>
-                                                                                                        <body>$uriPath/documentation/index.html &quot;&lt;BR&gt;&lt;DIV class=&apos;header2Text&apos;&gt;[llength $qcList] QuickCall Libraries in $uriPath:&lt;/DIV&gt;&quot;</body>
-                                                                                                    </command>
-                                                                                                    <applicationProperties type="com.fnfr.svt.execution.builtin.exec.WriteFilePropertyGroup"/>
-                                                                                                    <useFieldsInCommand>false</useFieldsInCommand>
-                                                                                                </item>
-                                                                                                <item guid="dec01ed5-449e-497a-abb8-79edd7e634ce" action="writeFile">
-                                                                                                    <command>
-                                                                                                        <body>$uriPath/README.md &quot;[llength $qcList] QuickCall Libraries in $uriPath:&quot;</body>
-                                                                                                    </command>
-                                                                                                    <applicationProperties type="com.fnfr.svt.execution.builtin.exec.WriteFilePropertyGroup"/>
-                                                                                                    <useFieldsInCommand>false</useFieldsInCommand>
-                                                                                                </item>
-                                                                                            </nestedSteps>
-                                                                                            <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
-                                                                                            <useFieldsInCommand>false</useFieldsInCommand>
-                                                                                        </item>
-                                                                                    </nestedSteps>
-                                                                                    <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
-                                                                                    <useFieldsInCommand>false</useFieldsInCommand>
-                                                                                </item>
-                                                                            </nestedSteps>
-                                                                            <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
-                                                                            <useFieldsInCommand>false</useFieldsInCommand>
-                                                                        </item>
-                                                                    </nestedSteps>
-                                                                    <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                                                                    <applicationProperties type="com.fnfr.svt.execution.builtin.exec.WriteFilePropertyGroup"/>
                                                                     <useFieldsInCommand>false</useFieldsInCommand>
                                                                 </item>
-                                                                <item guid="fe65bfef-2154-4588-af0f-e7d40f1e1256" action="comment">
+                                                            </nestedSteps>
+                                                            <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                                                            <useFieldsInCommand>false</useFieldsInCommand>
+                                                        </item>
+                                                    </nestedSteps>
+                                                    <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                                                    <useFieldsInCommand>false</useFieldsInCommand>
+                                                </item>
+                                                <item guid="10ec774e-be3d-4f87-8920-c78b718ecbbf" action="elseif">
+                                                    <command>
+                                                        <body>[llength [gget RM_LIB_URI_LIST]] &gt; 1</body>
+                                                    </command>
+                                                    <nestedSteps>
+                                                        <item guid="f8a32e5d-7ca1-4c8d-b9dd-137d9aae4ad8" action="comment">
+                                                            <command>
+                                                                <body>Write out &quot;Maps&quot; if more than one Proc lib in list</body>
+                                                            </command>
+                                                            <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                                                            <useFieldsInCommand>false</useFieldsInCommand>
+                                                        </item>
+                                                        <item guid="8446e1bc-3a50-4534-9d0a-57a0cd2d12e3" action="writeFile">
+                                                            <command>
+                                                                <body>$uriPath/documentation/index.html &quot;&lt;BR&gt;&lt;DIV class=&apos;normalText&apos;&gt;[llength [gget RM_LIB_URI_LIST]] Response Maps in $uriPath&lt;/DIV&gt;&quot;</body>
+                                                            </command>
+                                                            <applicationProperties type="com.fnfr.svt.execution.builtin.exec.WriteFilePropertyGroup"/>
+                                                            <useFieldsInCommand>false</useFieldsInCommand>
+                                                        </item>
+                                                        <item guid="1a3209f5-ad90-45bc-860d-a93a0731b362" action="writeFile">
+                                                            <command>
+                                                                <body>$uriPath/README.md &quot;[llength [gget RM_LIB_URI_LIST]] Response Maps in $uriPath&quot;</body>
+                                                            </command>
+                                                            <applicationProperties type="com.fnfr.svt.execution.builtin.exec.WriteFilePropertyGroup"/>
+                                                            <useFieldsInCommand>false</useFieldsInCommand>
+                                                        </item>
+                                                    </nestedSteps>
+                                                    <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                                                    <useFieldsInCommand>false</useFieldsInCommand>
+                                                </item>
+                                            </nestedSteps>
+                                            <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                                            <useFieldsInCommand>false</useFieldsInCommand>
+                                        </item>
+                                    </nestedSteps>
+                                    <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                                    <useFieldsInCommand>false</useFieldsInCommand>
+                                </item>
+                            </nestedSteps>
+                            <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                            <useFieldsInCommand>false</useFieldsInCommand>
+                        </item>
+                    </nestedSteps>
+                    <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                    <useFieldsInCommand>false</useFieldsInCommand>
+                </item>
+            </steps>
+            <multilineDescription>Build a separate list of QuickCall and Procedure libraries</multilineDescription>
+            <arguments>
+                <item name="uriPath">
+                    <description>URI to project</description>
+                </item>
+            </arguments>
+        </item>
+        <item name="writeInfo">
+            <description>Append info to HTML and MD</description>
+            <steps>
+                <item guid="e1d4501b-4cc2-434a-bef0-60714c238a84" action="foreach">
+                    <command>
+                        <body>uri $uriList</body>
+                    </command>
+                    <nestedSteps>
+                        <item guid="9d0aacd5-d659-41bb-9046-8971c3e64c62" action="eval">
+                            <command>
+                                <body>set headline &quot;&quot;</body>
+                            </command>
+                            <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                            <useFieldsInCommand>false</useFieldsInCommand>
+                        </item>
+                        <item guid="fbbe6fcf-570e-4cda-a0fb-a0ecfea6cec5" action="eval">
+                            <command>
+                                <body>set description &quot;&quot;</body>
+                            </command>
+                            <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                            <useFieldsInCommand>false</useFieldsInCommand>
+                        </item>
+                        <item guid="d1f79b8e-5d56-4b53-9b33-0d51f514caf5" action="readFile">
+                            <command>
+                                <body>$uri</body>
+                            </command>
+                            <postProcessing>
+                                <analysisRules>
+                                    <item>
+                                        <extractorInfo extractorType="query">
+                                            <extractorProperties type="com.fnfr.svt.mapping.execution.extractors.QueryDataExtractorPropertyGroup">
+                                                <query>fn:count(mapped/Xml/testCase/general/documentation)</query>
+                                            </extractorProperties>
+                                        </extractorInfo>
+                                        <processorInfo ruleType="assert">
+                                            <ruleProperties type="com.fnfr.svt.execution.builtin.processors.AssertionPropertyGroup">
+                                                <expression>$value == 1</expression>
+                                                <actionsWhenFalse>
+                                                    <item actionId="DeclareExecutionIssue">
+                                                        <actionProperties type="com.fnfr.svt.execution.builtin.actions.ExecutionIssuePropertyGroup" severity="Warning">
+                                                            <message>Headline missing: $uri</message>
+                                                        </actionProperties>
+                                                    </item>
+                                                </actionsWhenFalse>
+                                            </ruleProperties>
+                                        </processorInfo>
+                                    </item>
+                                    <item>
+                                        <extractorInfo extractorType="query">
+                                            <extractorProperties type="com.fnfr.svt.mapping.execution.extractors.QueryDataExtractorPropertyGroup">
+                                                <query>fn:count(mapped/Xml/testCase/general/notes)</query>
+                                            </extractorProperties>
+                                        </extractorInfo>
+                                        <processorInfo ruleType="assert">
+                                            <ruleProperties type="com.fnfr.svt.execution.builtin.processors.AssertionPropertyGroup">
+                                                <expression>$value == 1</expression>
+                                                <actionsWhenFalse>
+                                                    <item actionId="Eval">
+                                                        <actionProperties type="com.fnfr.svt.execution.builtin.actions.EvalActionPropertyGroup">
+                                                            <statement>set description &quot;&quot;</statement>
+                                                        </actionProperties>
+                                                    </item>
+                                                    <item actionId="DeclareExecutionIssue">
+                                                        <actionProperties type="com.fnfr.svt.execution.builtin.actions.ExecutionIssuePropertyGroup" severity="Warning">
+                                                            <message>Description missing: $uri</message>
+                                                        </actionProperties>
+                                                    </item>
+                                                </actionsWhenFalse>
+                                            </ruleProperties>
+                                        </processorInfo>
+                                    </item>
+                                    <item>
+                                        <extractorInfo extractorType="query">
+                                            <extractorProperties type="com.fnfr.svt.mapping.execution.extractors.QueryDataExtractorPropertyGroup" declareNoMatchIssue="false">
+                                                <query>//testCase/general/documentation</query>
+                                            </extractorProperties>
+                                        </extractorInfo>
+                                        <processorInfo ruleType="store">
+                                            <ruleProperties type="com.fnfr.svt.execution.builtin.processors.StoreProcessorPropertyGroup">
+                                                <storageLocation>headline</storageLocation>
+                                            </ruleProperties>
+                                        </processorInfo>
+                                    </item>
+                                    <item>
+                                        <extractorInfo extractorType="query">
+                                            <extractorProperties type="com.fnfr.svt.mapping.execution.extractors.QueryDataExtractorPropertyGroup" declareNoMatchIssue="false">
+                                                <query>//testCase/general/notes</query>
+                                            </extractorProperties>
+                                        </extractorInfo>
+                                        <processorInfo ruleType="store">
+                                            <ruleProperties type="com.fnfr.svt.execution.builtin.processors.StoreProcessorPropertyGroup">
+                                                <storageLocation>description</storageLocation>
+                                            </ruleProperties>
+                                        </processorInfo>
+                                    </item>
+                                </analysisRules>
+                                <storeResponseAt>xmlResponse</storeResponseAt>
+                            </postProcessing>
+                            <eventHandlers>
+                                <item name="OnInternalError">
+                                    <item actionId="FailTest">
+                                        <actionProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                                    </item>
+                                </item>
+                            </eventHandlers>
+                            <applicationProperties type="com.fnfr.svt.execution.builtin.exec.ReadFilePropertyGroup"/>
+                        </item>
+                        <item guid="e7345942-5a59-4c80-b50c-a76ca53796af" action="writeFile">
+                            <command>
+                                <body>$uriPath/documentation/index.html &quot;&lt;br&gt;&quot;</body>
+                            </command>
+                            <applicationProperties type="com.fnfr.svt.execution.builtin.exec.WriteFilePropertyGroup"/>
+                            <useFieldsInCommand>false</useFieldsInCommand>
+                        </item>
+                        <item guid="a4bfe3c9-3b0c-44ba-b2fa-77e0aed9edbf" action="writeFile">
+                            <command>
+                                <body>$uriPath/documentation/index.html &quot;&lt;DIV class=&apos;header2Text&apos;&gt;Library: $uri&lt;/DIV&gt;&quot;</body>
+                            </command>
+                            <applicationProperties type="com.fnfr.svt.execution.builtin.exec.WriteFilePropertyGroup"/>
+                            <useFieldsInCommand>false</useFieldsInCommand>
+                        </item>
+                        <item guid="d6d7a1ee-509a-48dd-852c-ff3af95c9a5b" action="writeFile">
+                            <command>
+                                <body>$uriPath/README.md &quot;## Library: $uri&quot;</body>
+                            </command>
+                            <applicationProperties type="com.fnfr.svt.execution.builtin.exec.WriteFilePropertyGroup"/>
+                            <useFieldsInCommand>false</useFieldsInCommand>
+                        </item>
+                        <item guid="cfd71337-cc07-4756-85b6-2180897769ac" action="if">
+                            <command>
+                                <body>$headline != &quot;&quot;</body>
+                            </command>
+                            <nestedSteps>
+                                <item guid="83ccaf22-45e4-4bf5-8cb6-fb7ed1bc635d" action="then">
+                                    <nestedSteps>
+                                        <item guid="9db25378-65e8-460c-9695-d53dbd4b6007" action="writeFile">
+                                            <command>
+                                                <body>$uriPath/documentation/index.html &quot;&lt;DIV class=&apos;header3Text&apos;&gt;Headline: $headline&lt;/DIV&gt;&quot;</body>
+                                            </command>
+                                            <applicationProperties type="com.fnfr.svt.execution.builtin.exec.WriteFilePropertyGroup"/>
+                                            <useFieldsInCommand>false</useFieldsInCommand>
+                                        </item>
+                                        <item guid="b8577758-d999-47b0-b9f8-cb93a113228d" action="writeFile">
+                                            <command>
+                                                <body>$uriPath/README.md &quot;## Headline: $headline&quot;</body>
+                                            </command>
+                                            <applicationProperties type="com.fnfr.svt.execution.builtin.exec.WriteFilePropertyGroup"/>
+                                            <useFieldsInCommand>false</useFieldsInCommand>
+                                        </item>
+                                    </nestedSteps>
+                                    <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                                    <useFieldsInCommand>false</useFieldsInCommand>
+                                </item>
+                            </nestedSteps>
+                            <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                            <useFieldsInCommand>false</useFieldsInCommand>
+                        </item>
+                        <item guid="0b7acfd9-33c0-4377-92ca-a00fb1343d78" action="if">
+                            <command>
+                                <body>$description != &quot;&quot;</body>
+                            </command>
+                            <nestedSteps>
+                                <item guid="d988e802-d969-43b4-8614-3512f5f0ffc7" action="then">
+                                    <nestedSteps>
+                                        <item guid="c4a0feab-de46-408b-8b88-05425bf44344" action="writeFile">
+                                            <command>
+                                                <body>$uriPath/documentation/index.html &quot;&lt;DIV class=&apos;header3Text&apos;&gt;Description: $description&lt;/DIV&gt;&quot;</body>
+                                            </command>
+                                            <applicationProperties type="com.fnfr.svt.execution.builtin.exec.WriteFilePropertyGroup"/>
+                                            <useFieldsInCommand>false</useFieldsInCommand>
+                                        </item>
+                                        <item guid="21c73be2-9f9c-43f5-9f30-97b07a32e8e5" action="writeFile">
+                                            <command>
+                                                <body>$uriPath/README.md &quot;Description: $description\\n&quot;</body>
+                                            </command>
+                                            <applicationProperties type="com.fnfr.svt.execution.builtin.exec.WriteFilePropertyGroup"/>
+                                            <useFieldsInCommand>false</useFieldsInCommand>
+                                        </item>
+                                    </nestedSteps>
+                                    <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                                    <useFieldsInCommand>false</useFieldsInCommand>
+                                </item>
+                            </nestedSteps>
+                            <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                            <useFieldsInCommand>false</useFieldsInCommand>
+                        </item>
+                        <item guid="a7069924-439b-4009-ab7a-267309f9f4f6" action="writeFile">
+                            <command>
+                                <body>$uriPath/documentation/index.html &quot;&lt;br&gt;&quot;</body>
+                            </command>
+                            <applicationProperties type="com.fnfr.svt.execution.builtin.exec.WriteFilePropertyGroup"/>
+                            <useFieldsInCommand>false</useFieldsInCommand>
+                        </item>
+                        <item guid="978390e1-c995-474b-a81f-287ff7714ed3" action="comment">
+                            <command>
+                                <body>Print each procedure</body>
+                            </command>
+                            <nestedSteps>
+                                <item guid="c78c33c1-420b-4dd8-ae71-68ae86d73ae2" action="foreach">
+                                    <command>
+                                        <body>procedure [query xmlResponse mapped/Xml/testCase/procedures/item/@name]</body>
+                                    </command>
+                                    <nestedSteps>
+                                        <item guid="2ef3a323-74a3-4c97-bf5e-092c295788ee" action="if">
+                                            <command>
+                                                <body>$procedure != &quot;main&quot;</body>
+                                            </command>
+                                            <nestedSteps>
+                                                <item guid="460c3b55-ab00-4fec-a4cd-82771844b0ac" action="then">
+                                                    <nestedSteps>
+                                                        <item guid="ec2ddb03-7bf9-4c49-ae08-112e01ecb1fc" action="comment">
+                                                            <command>
+                                                                <body>output the proc name and its description</body>
+                                                            </command>
+                                                            <nestedSteps>
+                                                                <item guid="653960da-2766-4954-b039-42d8eea802d1" action="writeFile">
                                                                     <command>
-                                                                        <body>For each of the QC Libs found</body>
+                                                                        <body>$uriPath/documentation/index.html &quot;&lt;DIV style=&apos;margin-left:30px; font-size:18px;color:darkgreen;font-weight:bold; font-family:courier&apos;&gt;$procedure&lt;/DIV&gt;&quot;</body>
+                                                                    </command>
+                                                                    <applicationProperties type="com.fnfr.svt.execution.builtin.exec.WriteFilePropertyGroup"/>
+                                                                    <useFieldsInCommand>false</useFieldsInCommand>
+                                                                </item>
+                                                                <item guid="c8ddb0a3-0205-4bce-adac-3c54a0f583a9" action="writeFile">
+                                                                    <command>
+                                                                        <body>$uriPath/README.md &quot;### $procedure&quot;</body>
+                                                                    </command>
+                                                                    <applicationProperties type="com.fnfr.svt.execution.builtin.exec.WriteFilePropertyGroup"/>
+                                                                    <useFieldsInCommand>false</useFieldsInCommand>
+                                                                </item>
+                                                                <item guid="2cb764c4-2755-4084-a404-c59a9ad277d4" action="writeFile">
+                                                                    <command>
+                                                                        <body>$uriPath/documentation/index.html &quot;&lt;DIV class=&apos;procText&apos;&gt;[query xmlResponse mapped/Xml/testCase/procedures/item\\[@name=&apos;$procedure&apos;\\]/multilineDescription]&lt;/DIV&gt;&lt;BR&gt;&quot;</body>
+                                                                    </command>
+                                                                    <applicationProperties type="com.fnfr.svt.execution.builtin.exec.WriteFilePropertyGroup"/>
+                                                                    <useFieldsInCommand>false</useFieldsInCommand>
+                                                                </item>
+                                                                <item guid="49180784-fd8c-49d5-b44a-f108957988e8" action="writeFile">
+                                                                    <command>
+                                                                        <body>$uriPath/README.md &quot;[query xmlResponse mapped/Xml/testCase/procedures/item\\[@name=&apos;$procedure&apos;\\]/multilineDescription]&quot;</body>
+                                                                    </command>
+                                                                    <applicationProperties type="com.fnfr.svt.execution.builtin.exec.WriteFilePropertyGroup"/>
+                                                                    <useFieldsInCommand>false</useFieldsInCommand>
+                                                                </item>
+                                                            </nestedSteps>
+                                                            <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                                                            <useFieldsInCommand>false</useFieldsInCommand>
+                                                        </item>
+                                                        <item guid="a3a2cfa0-0e34-4903-955d-02c1e560329b" action="comment">
+                                                            <command>
+                                                                <body>If there are arguments, create a table for these</body>
+                                                            </command>
+                                                            <nestedSteps>
+                                                                <item guid="9ece06e5-83aa-4c9e-ba3b-7bfa08e810a0" action="if">
+                                                                    <command>
+                                                                        <body>[query xmlResponse count(//procedures/item\\[@name=&apos;$procedure&apos;\\]/arguments/item/@name)] &gt; 0</body>
                                                                     </command>
                                                                     <nestedSteps>
-                                                                        <item guid="e26f4eb4-65ac-418b-95fb-ea8ab7fab47e" action="eval">
-                                                                            <command>
-                                                                                <body>set qcIndex 1</body>
-                                                                            </command>
-                                                                            <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
-                                                                            <useFieldsInCommand>false</useFieldsInCommand>
-                                                                        </item>
-                                                                        <item guid="ab5a8d4f-c018-4ff5-99ab-c3e151322c3a" action="foreach">
-                                                                            <command>
-                                                                                <body>qcLib $qcList</body>
-                                                                            </command>
+                                                                        <item guid="1e142185-a525-4614-aa66-e9e0c8a830dd" action="then">
                                                                             <nestedSteps>
-                                                                                <item guid="bb5b5c4d-ecf0-48ee-8c1c-2d9655eeffaa" action="readFile">
+                                                                                <item guid="bdc05a84-7261-4246-ad69-fd5b92c5c3af" action="writeFile">
                                                                                     <command>
-                                                                                        <body>$qcLib</body>
-                                                                                    </command>
-                                                                                    <postProcessing>
-                                                                                        <analysisRules>
-                                                                                            <item>
-                                                                                                <extractorInfo extractorType="query">
-                                                                                                    <extractorProperties type="com.fnfr.svt.mapping.execution.extractors.QueryDataExtractorPropertyGroup">
-                                                                                                        <query>fn:count(mapped/Xml/testCase/general/documentation)</query>
-                                                                                                    </extractorProperties>
-                                                                                                </extractorInfo>
-                                                                                                <processorInfo ruleType="assert">
-                                                                                                    <ruleProperties type="com.fnfr.svt.execution.builtin.processors.AssertionPropertyGroup">
-                                                                                                        <expression>$value == 1</expression>
-                                                                                                        <actionsWhenFalse>
-                                                                                                            <item actionId="Eval">
-                                                                                                                <actionProperties type="com.fnfr.svt.execution.builtin.actions.EvalActionPropertyGroup">
-                                                                                                                    <statement>set qcTitle $qcLib</statement>
-                                                                                                                </actionProperties>
-                                                                                                            </item>
-                                                                                                            <item actionId="SkipRemainingRules">
-                                                                                                                <actionProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
-                                                                                                            </item>
-                                                                                                        </actionsWhenFalse>
-                                                                                                    </ruleProperties>
-                                                                                                </processorInfo>
-                                                                                            </item>
-                                                                                            <item>
-                                                                                                <extractorInfo extractorType="query">
-                                                                                                    <extractorProperties type="com.fnfr.svt.mapping.execution.extractors.QueryDataExtractorPropertyGroup">
-                                                                                                        <query>mapped/Xml/testCase/general/documentation</query>
-                                                                                                    </extractorProperties>
-                                                                                                </extractorInfo>
-                                                                                                <processorInfo ruleType="store">
-                                                                                                    <ruleProperties type="com.fnfr.svt.execution.builtin.processors.StoreProcessorPropertyGroup">
-                                                                                                        <storageLocation>qcTitle</storageLocation>
-                                                                                                    </ruleProperties>
-                                                                                                </processorInfo>
-                                                                                            </item>
-                                                                                        </analysisRules>
-                                                                                        <storeResponseAt>xmlResponse</storeResponseAt>
-                                                                                    </postProcessing>
-                                                                                    <eventHandlers>
-                                                                                        <item name="OnInternalError">
-                                                                                            <item actionId="FailTest">
-                                                                                                <actionProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
-                                                                                            </item>
-                                                                                        </item>
-                                                                                    </eventHandlers>
-                                                                                    <applicationProperties type="com.fnfr.svt.execution.builtin.exec.ReadFilePropertyGroup"/>
-                                                                                </item>
-                                                                                <item guid="3db82af3-d187-4fb7-a102-f4ae42e9e575" action="writeFile">
-                                                                                    <command>
-                                                                                        <body>$uriPath/documentation/index.html &quot;&lt;BR&gt;&lt;DIV class=&apos;header2Text&apos;&gt;$qcTitle ($qcLib)&lt;/DIV&gt;&lt;BR&gt;&quot;</body>
+                                                                                        <body>$uriPath/documentation/index.html &quot;&lt;DIV class=&apos;normalText&apos;&gt;&lt;TABLE style=&apos;margin-left:30px; width=600px&apos;&gt;&quot;</body>
                                                                                     </command>
                                                                                     <applicationProperties type="com.fnfr.svt.execution.builtin.exec.WriteFilePropertyGroup"/>
                                                                                     <useFieldsInCommand>false</useFieldsInCommand>
                                                                                 </item>
-                                                                                <item guid="b4124bdc-fb7f-4617-b630-0f7fec0bb8ce" action="writeFile">
+                                                                                <item guid="e72ba309-cb6f-4244-815f-069db6053aaf" action="writeFile">
                                                                                     <command>
-                                                                                        <body>$uriPath/README.md &quot;## $qcTitle ($qcLib)&quot;</body>
-                                                                                    </command>
-                                                                                    <applicationProperties type="com.fnfr.svt.execution.builtin.exec.WriteFilePropertyGroup"/>
-                                                                                    <useFieldsInCommand>false</useFieldsInCommand>
-                                                                                </item>
-                                                                                <item guid="1bc1850b-cc85-4ad2-a8a5-374c1619c264" action="writeFile">
-                                                                                    <command>
-                                                                                        <body>$uriPath/documentation/index.html &quot;&lt;DIV class=&apos;qcNotesText&apos;&gt;[query xmlResponse //general/notes]&lt;/DIV&gt;&quot;</body>
-                                                                                    </command>
-                                                                                    <applicationProperties type="com.fnfr.svt.execution.builtin.exec.WriteFilePropertyGroup"/>
-                                                                                    <useFieldsInCommand>false</useFieldsInCommand>
-                                                                                </item>
-                                                                                <item guid="cf9c3ed2-ab81-4ac2-acf4-004338af994e" action="writeFile">
-                                                                                    <command>
-                                                                                        <body>$uriPath/README.md &quot;[query xmlResponse //general/notes]\\n&quot;</body>
-                                                                                    </command>
-                                                                                    <applicationProperties type="com.fnfr.svt.execution.builtin.exec.WriteFilePropertyGroup"/>
-                                                                                    <useFieldsInCommand>false</useFieldsInCommand>
-                                                                                </item>
-                                                                                <item guid="15bff4e4-2d8b-4a9d-a5ce-a1ca38a4343d" action="comment">
-                                                                                    <command>
-                                                                                        <body>Print each procedure</body>
-                                                                                    </command>
-                                                                                    <nestedSteps>
-                                                                                        <item guid="5321bae5-bd5e-4c0e-a868-6b8d9ad3b4bf" action="foreach">
-                                                                                            <command>
-                                                                                                <body>procedure [query xmlResponse mapped/Xml/testCase/procedures/item/@name]</body>
-                                                                                            </command>
-                                                                                            <nestedSteps>
-                                                                                                <item guid="b853fae3-7c0b-4945-a506-179cedb094e0" action="if">
-                                                                                                    <command>
-                                                                                                        <body>$procedure != &quot;main&quot;</body>
-                                                                                                    </command>
-                                                                                                    <nestedSteps>
-                                                                                                        <item guid="f1791117-6202-4505-b28b-51edf1e43e46" action="then">
-                                                                                                            <nestedSteps>
-                                                                                                                <item guid="9168d1fc-a414-42ed-9f54-efefe44868c9" action="comment">
-                                                                                                                    <command>
-                                                                                                                        <body>output the qc name and its description</body>
-                                                                                                                    </command>
-                                                                                                                    <nestedSteps>
-                                                                                                                        <item guid="6c47aba4-0ed7-4ef8-a4d8-5b9507b4384f" action="writeFile">
-                                                                                                                            <command>
-                                                                                                                                <body>$uriPath/documentation/index.html &quot;&lt;DIV style=&apos;margin-left:30px; font-size:18px;color:darkgreen;font-weight:bold; font-family:courier&apos;&gt;$procedure&lt;/DIV&gt;&quot;</body>
-                                                                                                                            </command>
-                                                                                                                            <applicationProperties type="com.fnfr.svt.execution.builtin.exec.WriteFilePropertyGroup"/>
-                                                                                                                            <useFieldsInCommand>false</useFieldsInCommand>
-                                                                                                                        </item>
-                                                                                                                        <item guid="0fca85f0-765d-4e5f-923f-3818b2f8ecad" action="writeFile">
-                                                                                                                            <command>
-                                                                                                                                <body>$uriPath/README.md &quot;### $procedure&quot;</body>
-                                                                                                                            </command>
-                                                                                                                            <applicationProperties type="com.fnfr.svt.execution.builtin.exec.WriteFilePropertyGroup"/>
-                                                                                                                            <useFieldsInCommand>false</useFieldsInCommand>
-                                                                                                                        </item>
-                                                                                                                        <item guid="2b9d4b97-a981-4248-9918-ee30a21e1880" action="writeFile">
-                                                                                                                            <command>
-                                                                                                                                <body>$uriPath/documentation/index.html &quot;&lt;DIV class=&apos;procText&apos;&gt;[query xmlResponse mapped/Xml/testCase/procedures/item\\[@name=&apos;$procedure&apos;\\]/multilineDescription]&lt;/DIV&gt;&lt;BR&gt;&quot;</body>
-                                                                                                                            </command>
-                                                                                                                            <applicationProperties type="com.fnfr.svt.execution.builtin.exec.WriteFilePropertyGroup"/>
-                                                                                                                            <useFieldsInCommand>false</useFieldsInCommand>
-                                                                                                                        </item>
-                                                                                                                        <item guid="cf13d8ca-2272-4e84-8779-e5d4630e9418" action="writeFile">
-                                                                                                                            <command>
-                                                                                                                                <body>$uriPath/README.md &quot;[query xmlResponse mapped/Xml/testCase/procedures/item\\[@name=&apos;$procedure&apos;\\]/multilineDescription]&quot;</body>
-                                                                                                                            </command>
-                                                                                                                            <applicationProperties type="com.fnfr.svt.execution.builtin.exec.WriteFilePropertyGroup"/>
-                                                                                                                            <useFieldsInCommand>false</useFieldsInCommand>
-                                                                                                                        </item>
-                                                                                                                    </nestedSteps>
-                                                                                                                    <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
-                                                                                                                    <useFieldsInCommand>false</useFieldsInCommand>
-                                                                                                                </item>
-                                                                                                                <item guid="6121313c-cff9-4e09-a5c6-35ebe7d74eac" action="comment">
-                                                                                                                    <command>
-                                                                                                                        <body>If there are arguments, create a table for these</body>
-                                                                                                                    </command>
-                                                                                                                    <nestedSteps>
-                                                                                                                        <item guid="4235e8cc-fb4d-42ab-8a28-432fbfd1180a" action="if">
-                                                                                                                            <command>
-                                                                                                                                <body>[query xmlResponse count(//procedures/item\\[@name=&apos;$procedure&apos;\\]/arguments/item/@name)] &gt; 0</body>
-                                                                                                                            </command>
-                                                                                                                            <nestedSteps>
-                                                                                                                                <item guid="82ab83c3-8ab6-408b-aa50-afa8e16bdad6" action="then">
-                                                                                                                                    <nestedSteps>
-                                                                                                                                        <item guid="1d7e56e4-8650-451b-ace7-ae159c00c709" action="writeFile">
-                                                                                                                                            <command>
-                                                                                                                                                <body>$uriPath/documentation/index.html &quot;&lt;DIV class=&apos;normalText&apos;&gt;&lt;TABLE style=&apos;margin-left:30px; width=600px&apos;&gt;&quot;</body>
-                                                                                                                                            </command>
-                                                                                                                                            <applicationProperties type="com.fnfr.svt.execution.builtin.exec.WriteFilePropertyGroup"/>
-                                                                                                                                            <useFieldsInCommand>false</useFieldsInCommand>
-                                                                                                                                        </item>
-                                                                                                                                        <item guid="4ffae232-7516-4b35-ae67-3aa7b231c5b1" action="writeFile">
-                                                                                                                                            <command>
-                                                                                                                                                <body>$uriPath/documentation/index.html  &quot;&lt;TR&gt;&lt;TH style=&apos;width:200px; padding:5px;color:darkblue;&apos; class=&apos;normalText&apos;&gt;Argument&lt;/TH&gt;
+                                                                                        <body>$uriPath/documentation/index.html  &quot;&lt;TR&gt;&lt;TH style=&apos;width:200px; padding:5px;color:darkblue;&apos; class=&apos;normalText&apos;&gt;Argument&lt;/TH&gt;
 &lt;TH style=&apos;width:400px; padding:5px;color:darkblue;&apos; class=&apos;normalText&apos;&gt;Description&lt;/TH&gt;&lt;/TR&gt;&quot;</body>
-                                                                                                                                            </command>
-                                                                                                                                            <applicationProperties type="com.fnfr.svt.execution.builtin.exec.WriteFilePropertyGroup"/>
-                                                                                                                                            <useFieldsInCommand>false</useFieldsInCommand>
-                                                                                                                                        </item>
-                                                                                                                                        <item guid="d979ac35-01cb-432c-a108-9b4ef969e15a" action="writeFile">
-                                                                                                                                            <command>
-                                                                                                                                                <body>$uriPath/README.md  &quot;\\n&quot;</body>
-                                                                                                                                            </command>
-                                                                                                                                            <applicationProperties type="com.fnfr.svt.execution.builtin.exec.WriteFilePropertyGroup"/>
-                                                                                                                                            <useFieldsInCommand>false</useFieldsInCommand>
-                                                                                                                                        </item>
-                                                                                                                                        <item guid="da4552f6-543f-4005-93c3-1d1f3be296f2" action="writeFile">
-                                                                                                                                            <command>
-                                                                                                                                                <body>$uriPath/README.md  &quot;Argument | Description&quot;</body>
-                                                                                                                                            </command>
-                                                                                                                                            <applicationProperties type="com.fnfr.svt.execution.builtin.exec.WriteFilePropertyGroup"/>
-                                                                                                                                            <useFieldsInCommand>false</useFieldsInCommand>
-                                                                                                                                        </item>
-                                                                                                                                        <item guid="4296a740-b016-4a73-a32c-e365dd11d3f7" action="writeFile">
-                                                                                                                                            <command>
-                                                                                                                                                <body>$uriPath/README.md  &quot;------------ | -------------&quot;</body>
-                                                                                                                                            </command>
-                                                                                                                                            <applicationProperties type="com.fnfr.svt.execution.builtin.exec.WriteFilePropertyGroup"/>
-                                                                                                                                            <useFieldsInCommand>false</useFieldsInCommand>
-                                                                                                                                        </item>
-                                                                                                                                        <item guid="19171182-c3b9-41e8-a13d-be6e0fbda91f" action="comment">
-                                                                                                                                            <command>
-                                                                                                                                                <body>Each argument is a new line in the table</body>
-                                                                                                                                            </command>
-                                                                                                                                            <nestedSteps>
-                                                                                                                                                <item guid="7ada5636-fa72-4dea-a77f-e135c1584b0f" action="foreach">
-                                                                                                                                                    <command>
-                                                                                                                                                        <body>argument [query xmlResponse //procedures/item\\[@name=&apos;$procedure&apos;\\]/arguments/item/@name]</body>
-                                                                                                                                                    </command>
-                                                                                                                                                    <nestedSteps>
-                                                                                                                                                        <item guid="c50f439d-680f-4c60-a074-0c91ebb6642d" action="writeFile">
-                                                                                                                                                            <command>
-                                                                                                                                                                <body>$uriPath/documentation/index.html &quot;&lt;TR&gt;&lt;TD style=&apos;width:200px; padding:5px;color:darkblue&apos; class=&apos;normalText&apos;&gt;$argument&lt;/TD&gt;
+                                                                                    </command>
+                                                                                    <applicationProperties type="com.fnfr.svt.execution.builtin.exec.WriteFilePropertyGroup"/>
+                                                                                    <useFieldsInCommand>false</useFieldsInCommand>
+                                                                                </item>
+                                                                                <item guid="8bf0e7bb-353c-49dc-ab25-ac4edd14b397" action="writeFile">
+                                                                                    <command>
+                                                                                        <body>$uriPath/README.md  &quot;\\n&quot;</body>
+                                                                                    </command>
+                                                                                    <applicationProperties type="com.fnfr.svt.execution.builtin.exec.WriteFilePropertyGroup"/>
+                                                                                    <useFieldsInCommand>false</useFieldsInCommand>
+                                                                                </item>
+                                                                                <item guid="a1982221-9526-4d0f-bfee-2b3522c6dc1a" action="writeFile">
+                                                                                    <command>
+                                                                                        <body>$uriPath/README.md  &quot;Argument | Description&quot;</body>
+                                                                                    </command>
+                                                                                    <applicationProperties type="com.fnfr.svt.execution.builtin.exec.WriteFilePropertyGroup"/>
+                                                                                    <useFieldsInCommand>false</useFieldsInCommand>
+                                                                                </item>
+                                                                                <item guid="8e47c253-687f-4bfb-9739-063e083279c1" action="writeFile">
+                                                                                    <command>
+                                                                                        <body>$uriPath/README.md  &quot;------------ | -------------&quot;</body>
+                                                                                    </command>
+                                                                                    <applicationProperties type="com.fnfr.svt.execution.builtin.exec.WriteFilePropertyGroup"/>
+                                                                                    <useFieldsInCommand>false</useFieldsInCommand>
+                                                                                </item>
+                                                                                <item guid="aa32d9bd-b972-4f76-a9f2-85806490a954" action="comment">
+                                                                                    <command>
+                                                                                        <body>Each argument is a new line in the table</body>
+                                                                                    </command>
+                                                                                    <nestedSteps>
+                                                                                        <item guid="6b80d163-61f1-4297-a5ae-10a049143f26" action="foreach">
+                                                                                            <command>
+                                                                                                <body>argument [query xmlResponse //procedures/item\\[@name=&apos;$procedure&apos;\\]/arguments/item/@name]</body>
+                                                                                            </command>
+                                                                                            <nestedSteps>
+                                                                                                <item guid="91d3523e-ed46-46cf-ae64-be5120491bec" action="writeFile">
+                                                                                                    <command>
+                                                                                                        <body>$uriPath/documentation/index.html &quot;&lt;TR&gt;&lt;TD style=&apos;width:200px; padding:5px;color:darkblue&apos; class=&apos;normalText&apos;&gt;$argument&lt;/TD&gt;
 &lt;TD style=&apos;width:400px; padding:5px;color:darkblue&apos; class=&apos;normalText&apos;&gt;[query xmlResponse //procedures/item\\[@name=&apos;$procedure&apos;\\]/arguments/item\\[@name=&apos;$argument&apos;\\]/description] &lt;/TD&gt;
 &lt;/TR&gt;&quot;</body>
-                                                                                                                                                            </command>
-                                                                                                                                                            <applicationProperties type="com.fnfr.svt.execution.builtin.exec.WriteFilePropertyGroup"/>
-                                                                                                                                                            <useFieldsInCommand>false</useFieldsInCommand>
-                                                                                                                                                        </item>
-                                                                                                                                                        <item guid="86605cb1-746d-4dd9-96f9-6440807f62d4" action="writeFile">
-                                                                                                                                                            <command>
-                                                                                                                                                                <body>$uriPath/README.md &quot;$argument | [query xmlResponse //procedures/item\\[@name=&apos;$procedure&apos;\\]/arguments/item\\[@name=&apos;$argument&apos;\\]/description]&quot;</body>
-                                                                                                                                                            </command>
-                                                                                                                                                            <applicationProperties type="com.fnfr.svt.execution.builtin.exec.WriteFilePropertyGroup"/>
-                                                                                                                                                            <useFieldsInCommand>false</useFieldsInCommand>
-                                                                                                                                                        </item>
-                                                                                                                                                    </nestedSteps>
-                                                                                                                                                    <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
-                                                                                                                                                    <useFieldsInCommand>false</useFieldsInCommand>
-                                                                                                                                                </item>
-                                                                                                                                            </nestedSteps>
-                                                                                                                                            <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
-                                                                                                                                            <useFieldsInCommand>false</useFieldsInCommand>
-                                                                                                                                        </item>
-                                                                                                                                        <item guid="a4f01ff3-fbdf-45d7-9951-451f36af3896" action="writeFile">
-                                                                                                                                            <command>
-                                                                                                                                                <body>$uriPath/documentation/index.html &quot;&lt;/TABLE&gt;&lt;/DIV&gt;&lt;br&gt;&quot;</body>
-                                                                                                                                            </command>
-                                                                                                                                            <applicationProperties type="com.fnfr.svt.execution.builtin.exec.WriteFilePropertyGroup"/>
-                                                                                                                                            <useFieldsInCommand>false</useFieldsInCommand>
-                                                                                                                                        </item>
-                                                                                                                                    </nestedSteps>
-                                                                                                                                    <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
-                                                                                                                                    <useFieldsInCommand>false</useFieldsInCommand>
-                                                                                                                                </item>
-                                                                                                                            </nestedSteps>
-                                                                                                                            <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
-                                                                                                                            <useFieldsInCommand>false</useFieldsInCommand>
-                                                                                                                        </item>
-                                                                                                                    </nestedSteps>
-                                                                                                                    <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
-                                                                                                                    <useFieldsInCommand>false</useFieldsInCommand>
-                                                                                                                </item>
-                                                                                                            </nestedSteps>
-                                                                                                            <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
-                                                                                                            <useFieldsInCommand>false</useFieldsInCommand>
-                                                                                                        </item>
-                                                                                                    </nestedSteps>
-                                                                                                    <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                                                                                                    </command>
+                                                                                                    <applicationProperties type="com.fnfr.svt.execution.builtin.exec.WriteFilePropertyGroup"/>
+                                                                                                    <useFieldsInCommand>false</useFieldsInCommand>
+                                                                                                </item>
+                                                                                                <item guid="846f9525-68fe-40f4-b562-25be0336009d" action="writeFile">
+                                                                                                    <command>
+                                                                                                        <body>$uriPath/README.md &quot;$argument | [query xmlResponse //procedures/item\\[@name=&apos;$procedure&apos;\\]/arguments/item\\[@name=&apos;$argument&apos;\\]/description]&quot;</body>
+                                                                                                    </command>
+                                                                                                    <applicationProperties type="com.fnfr.svt.execution.builtin.exec.WriteFilePropertyGroup"/>
                                                                                                     <useFieldsInCommand>false</useFieldsInCommand>
                                                                                                 </item>
                                                                                             </nestedSteps>
@@ -935,18 +2064,11 @@ H1,H2{padding-left:15px}
                                                                                     <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
                                                                                     <useFieldsInCommand>false</useFieldsInCommand>
                                                                                 </item>
-                                                                                <item guid="7aa41836-5949-4155-becb-c273976a93fa" action="writeFile">
+                                                                                <item guid="c47a8d52-2741-485a-8c38-7de58dc7873a" action="writeFile">
                                                                                     <command>
-                                                                                        <body>$uriPath/documentation/index.html &quot;&lt;br&gt;&quot;</body>
+                                                                                        <body>$uriPath/documentation/index.html &quot;&lt;/TABLE&gt;&lt;/DIV&gt;&lt;br&gt;&quot;</body>
                                                                                     </command>
                                                                                     <applicationProperties type="com.fnfr.svt.execution.builtin.exec.WriteFilePropertyGroup"/>
-                                                                                    <useFieldsInCommand>false</useFieldsInCommand>
-                                                                                </item>
-                                                                                <item guid="e1d6387e-85cc-4c28-9d0f-dbf446bd325c" action="eval">
-                                                                                    <command>
-                                                                                        <body>incr qcIndex</body>
-                                                                                    </command>
-                                                                                    <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
                                                                                     <useFieldsInCommand>false</useFieldsInCommand>
                                                                                 </item>
                                                                             </nestedSteps>
@@ -977,11 +2099,350 @@ H1,H2{padding-left:15px}
                             <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
                             <useFieldsInCommand>false</useFieldsInCommand>
                         </item>
+                        <item guid="c0c98c56-3b54-4174-a347-3abf00d7dc0a" action="writeFile">
+                            <command>
+                                <body>$uriPath/documentation/index.html &quot;&lt;br&gt;&quot;</body>
+                            </command>
+                            <applicationProperties type="com.fnfr.svt.execution.builtin.exec.WriteFilePropertyGroup"/>
+                            <useFieldsInCommand>false</useFieldsInCommand>
+                        </item>
                     </nestedSteps>
                     <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
                     <useFieldsInCommand>false</useFieldsInCommand>
                 </item>
             </steps>
+            <multilineDescription>Append to HTML and MD: procedure names, descriptions and arguments</multilineDescription>
+            <arguments>
+                <item name="uriPath">
+                    <description>URI to project</description>
+                </item>
+                <item name="uriList">
+                    <description>List of library URI&apos;s </description>
+                </item>
+            </arguments>
+        </item>
+        <item name="writeRMInfo">
+            <description>Append info to HTML and MD</description>
+            <steps>
+                <item guid="fc6cdf62-ead0-4be9-b497-e7dcdf034e1b" action="foreach">
+                    <command>
+                        <body>uri $uriList</body>
+                    </command>
+                    <nestedSteps>
+                        <item guid="4db4a419-1788-404f-bbcd-2e34745d31df" action="eval">
+                            <command>
+                                <body>set headline &quot;&quot;</body>
+                            </command>
+                            <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                            <useFieldsInCommand>false</useFieldsInCommand>
+                        </item>
+                        <item guid="6b613a31-1a27-42d7-a8dc-d066b037ced7" action="eval">
+                            <command>
+                                <body>set description &quot;&quot;</body>
+                            </command>
+                            <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                            <useFieldsInCommand>false</useFieldsInCommand>
+                        </item>
+                        <item guid="48f6fc38-5d86-41aa-9824-dede42ec0798" action="readFile">
+                            <command>
+                                <body>$uri</body>
+                            </command>
+                            <postProcessing>
+                                <analysisRules>
+                                    <item>
+                                        <extractorInfo extractorType="query">
+                                            <extractorProperties type="com.fnfr.svt.mapping.execution.extractors.QueryDataExtractorPropertyGroup">
+                                                <query>fn:count(mapped/Xml/testCase/general/isProcedureLibrary)</query>
+                                            </extractorProperties>
+                                        </extractorInfo>
+                                        <processorInfo ruleType="assert">
+                                            <ruleProperties type="com.fnfr.svt.execution.builtin.processors.AssertionPropertyGroup">
+                                                <expression>$value == 1</expression>
+                                                <actionsWhenFalse>
+                                                    <item actionId="Eval">
+                                                        <actionProperties type="com.fnfr.svt.execution.builtin.actions.EvalActionPropertyGroup">
+                                                            <statement>set isProcedureLibrary true</statement>
+                                                        </actionProperties>
+                                                    </item>
+                                                    <item actionId="SkipRemainingRules">
+                                                        <actionProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                                                    </item>
+                                                    <item actionId="Continue">
+                                                        <actionProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                                                    </item>
+                                                </actionsWhenFalse>
+                                            </ruleProperties>
+                                        </processorInfo>
+                                        <skip>true</skip>
+                                    </item>
+                                    <item>
+                                        <extractorInfo extractorType="query">
+                                            <extractorProperties type="com.fnfr.svt.mapping.execution.extractors.QueryDataExtractorPropertyGroup">
+                                                <query>fn:count(mapped/Xml/ResponseMap/headline)</query>
+                                            </extractorProperties>
+                                        </extractorInfo>
+                                        <processorInfo ruleType="assert">
+                                            <ruleProperties type="com.fnfr.svt.execution.builtin.processors.AssertionPropertyGroup">
+                                                <expression>$value == 1</expression>
+                                                <actionsWhenFalse>
+                                                    <item actionId="DeclareExecutionIssue">
+                                                        <actionProperties type="com.fnfr.svt.execution.builtin.actions.ExecutionIssuePropertyGroup" severity="Warning">
+                                                            <message>Headline missing: $uri</message>
+                                                        </actionProperties>
+                                                    </item>
+                                                </actionsWhenFalse>
+                                            </ruleProperties>
+                                        </processorInfo>
+                                    </item>
+                                    <item>
+                                        <extractorInfo extractorType="query">
+                                            <extractorProperties type="com.fnfr.svt.mapping.execution.extractors.QueryDataExtractorPropertyGroup">
+                                                <query>fn:count(mapped/Xml/ResponseMap/notes)</query>
+                                            </extractorProperties>
+                                        </extractorInfo>
+                                        <processorInfo ruleType="assert">
+                                            <ruleProperties type="com.fnfr.svt.execution.builtin.processors.AssertionPropertyGroup">
+                                                <expression>$value == 1</expression>
+                                                <actionsWhenFalse>
+                                                    <item actionId="Eval">
+                                                        <actionProperties type="com.fnfr.svt.execution.builtin.actions.EvalActionPropertyGroup">
+                                                            <statement>set description &quot;&quot;</statement>
+                                                        </actionProperties>
+                                                    </item>
+                                                    <item actionId="DeclareExecutionIssue">
+                                                        <actionProperties type="com.fnfr.svt.execution.builtin.actions.ExecutionIssuePropertyGroup" severity="Warning">
+                                                            <message>Description missing: $uri</message>
+                                                        </actionProperties>
+                                                    </item>
+                                                </actionsWhenFalse>
+                                            </ruleProperties>
+                                        </processorInfo>
+                                    </item>
+                                    <item>
+                                        <extractorInfo extractorType="query">
+                                            <extractorProperties type="com.fnfr.svt.mapping.execution.extractors.QueryDataExtractorPropertyGroup" declareNoMatchIssue="false">
+                                                <query>//ResponseMap/headline</query>
+                                            </extractorProperties>
+                                        </extractorInfo>
+                                        <processorInfo ruleType="store">
+                                            <ruleProperties type="com.fnfr.svt.execution.builtin.processors.StoreProcessorPropertyGroup">
+                                                <storageLocation>headline</storageLocation>
+                                            </ruleProperties>
+                                        </processorInfo>
+                                    </item>
+                                    <item>
+                                        <extractorInfo extractorType="query">
+                                            <extractorProperties type="com.fnfr.svt.mapping.execution.extractors.QueryDataExtractorPropertyGroup" declareNoMatchIssue="false">
+                                                <query>//ResponseMap/notes</query>
+                                            </extractorProperties>
+                                        </extractorInfo>
+                                        <processorInfo ruleType="store">
+                                            <ruleProperties type="com.fnfr.svt.execution.builtin.processors.StoreProcessorPropertyGroup">
+                                                <storageLocation>description</storageLocation>
+                                            </ruleProperties>
+                                        </processorInfo>
+                                    </item>
+                                </analysisRules>
+                                <storeResponseAt>xmlResponse</storeResponseAt>
+                            </postProcessing>
+                            <eventHandlers>
+                                <item name="OnInternalError">
+                                    <item actionId="FailTest">
+                                        <actionProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                                    </item>
+                                </item>
+                            </eventHandlers>
+                            <applicationProperties type="com.fnfr.svt.execution.builtin.exec.ReadFilePropertyGroup"/>
+                        </item>
+                        <item guid="2dcb0534-a2bc-4c27-9355-fa9626861a9b" action="writeFile">
+                            <command>
+                                <body>$uriPath/documentation/index.html &quot;&lt;br&gt;&quot;</body>
+                            </command>
+                            <applicationProperties type="com.fnfr.svt.execution.builtin.exec.WriteFilePropertyGroup"/>
+                            <useFieldsInCommand>false</useFieldsInCommand>
+                        </item>
+                        <item guid="c99ee9b8-0446-42d9-836e-ab65e04bd597" action="writeFile">
+                            <command>
+                                <body>$uriPath/documentation/index.html &quot;&lt;DIV class=&apos;header2Text&apos;&gt;Response Map: $uri&lt;/DIV&gt;&quot;</body>
+                            </command>
+                            <applicationProperties type="com.fnfr.svt.execution.builtin.exec.WriteFilePropertyGroup"/>
+                            <useFieldsInCommand>false</useFieldsInCommand>
+                        </item>
+                        <item guid="f7619b4f-8e55-4373-848b-4b175c374993" action="writeFile">
+                            <command>
+                                <body>$uriPath/README.md &quot;## Response Map: $uri&quot;</body>
+                            </command>
+                            <applicationProperties type="com.fnfr.svt.execution.builtin.exec.WriteFilePropertyGroup"/>
+                            <useFieldsInCommand>false</useFieldsInCommand>
+                        </item>
+                        <item guid="3dd40b01-a458-4453-bdd4-8fe927492d28" action="if">
+                            <command>
+                                <body>$headline != &quot;&quot;</body>
+                            </command>
+                            <nestedSteps>
+                                <item guid="c5e20aa1-68d3-4a6b-9bfa-7aee785a40aa" action="then">
+                                    <nestedSteps>
+                                        <item guid="e7bfa722-25d0-4880-b5d6-5b9e3eeed677" action="writeFile">
+                                            <command>
+                                                <body>$uriPath/documentation/index.html &quot;&lt;DIV class=&apos;header3Text&apos;&gt;Headline: $headline&lt;/DIV&gt;&quot;</body>
+                                            </command>
+                                            <applicationProperties type="com.fnfr.svt.execution.builtin.exec.WriteFilePropertyGroup"/>
+                                            <useFieldsInCommand>false</useFieldsInCommand>
+                                        </item>
+                                        <item guid="a9938a80-6d05-4d8c-a97e-5b199d5b2102" action="writeFile">
+                                            <command>
+                                                <body>$uriPath/README.md &quot;## Headline: $headline&quot;</body>
+                                            </command>
+                                            <applicationProperties type="com.fnfr.svt.execution.builtin.exec.WriteFilePropertyGroup"/>
+                                            <useFieldsInCommand>false</useFieldsInCommand>
+                                        </item>
+                                    </nestedSteps>
+                                    <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                                    <useFieldsInCommand>false</useFieldsInCommand>
+                                </item>
+                            </nestedSteps>
+                            <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                            <useFieldsInCommand>false</useFieldsInCommand>
+                        </item>
+                        <item guid="8e3ac0ea-1f3e-4deb-bc8c-58c69ab2bcc6" action="if">
+                            <command>
+                                <body>$description != &quot;&quot;</body>
+                            </command>
+                            <nestedSteps>
+                                <item guid="4cea592a-2aae-4a96-bf82-9ea06256022a" action="then">
+                                    <nestedSteps>
+                                        <item guid="229d84c2-6bd2-44fe-8772-568e12970f15" action="writeFile">
+                                            <command>
+                                                <body>$uriPath/documentation/index.html &quot;&lt;DIV class=&apos;header3Text&apos;&gt;Description: $description&lt;/DIV&gt;&quot;</body>
+                                            </command>
+                                            <applicationProperties type="com.fnfr.svt.execution.builtin.exec.WriteFilePropertyGroup"/>
+                                            <useFieldsInCommand>false</useFieldsInCommand>
+                                        </item>
+                                        <item guid="bf02b670-5a64-4325-8834-ceac2c2f362d" action="writeFile">
+                                            <command>
+                                                <body>$uriPath/README.md &quot;Description: $description\\n&quot;</body>
+                                            </command>
+                                            <applicationProperties type="com.fnfr.svt.execution.builtin.exec.WriteFilePropertyGroup"/>
+                                            <useFieldsInCommand>false</useFieldsInCommand>
+                                        </item>
+                                    </nestedSteps>
+                                    <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                                    <useFieldsInCommand>false</useFieldsInCommand>
+                                </item>
+                            </nestedSteps>
+                            <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                            <useFieldsInCommand>false</useFieldsInCommand>
+                        </item>
+                        <item guid="0983cb4b-7aba-40d7-a398-69756e42d434" action="writeFile">
+                            <command>
+                                <body>$uriPath/documentation/index.html &quot;&lt;br&gt;&quot;</body>
+                            </command>
+                            <applicationProperties type="com.fnfr.svt.execution.builtin.exec.WriteFilePropertyGroup"/>
+                            <useFieldsInCommand>false</useFieldsInCommand>
+                        </item>
+                    </nestedSteps>
+                    <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                    <useFieldsInCommand>false</useFieldsInCommand>
+                </item>
+            </steps>
+            <multilineDescription>Append to HTML and MD: procedure names, descriptions and arguments</multilineDescription>
+            <arguments>
+                <item name="uriPath">
+                    <description>URI to project</description>
+                </item>
+                <item name="uriList">
+                    <description>List of response map URI&apos;s </description>
+                </item>
+            </arguments>
+        </item>
+        <item name="fileChanged">
+            <description>Determine if file has been changed since a specified date</description>
+            <steps>
+                <item guid="d0796aeb-ecd8-4837-8e04-65bb2f417532" action="scriptEval">
+                    <command>
+                        <body>clock scan [param changedDate]</body>
+                    </command>
+                    <postProcessing>
+                        <analysisRules>
+                            <item>
+                                <extractorInfo extractorType="regex">
+                                    <extractorProperties type="com.fnfr.svt.mapping.regex.extractors.RegexExtractorPropertyGroup" useLineMode="true">
+                                        <regex>^(\\d+)$</regex>
+                                    </extractorProperties>
+                                </extractorInfo>
+                                <processorInfo ruleType="store">
+                                    <ruleProperties type="com.fnfr.svt.execution.builtin.processors.StoreProcessorPropertyGroup">
+                                        <storageLocation>changeSeconds</storageLocation>
+                                    </ruleProperties>
+                                </processorInfo>
+                            </item>
+                        </analysisRules>
+                    </postProcessing>
+                    <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                </item>
+                <item guid="751979f2-f164-4f86-8191-0e9f2a508c93" action="eval">
+                    <command>
+                        <body>set changed 0</body>
+                    </command>
+                    <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                    <useFieldsInCommand>false</useFieldsInCommand>
+                </item>
+                <item guid="311d29a1-8718-411c-9abc-b27b8a958be8" action="eval">
+                    <command>
+                        <body>set fullFileName [string map {\\\\ /} [file uriToPath $uri]]</body>
+                    </command>
+                    <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                    <useFieldsInCommand>false</useFieldsInCommand>
+                </item>
+                <item guid="202127c5-2ffc-4a22-b42e-34aa74b6ec9c" action="scriptEval">
+                    <command>
+                        <body>file mtime $fullFileName</body>
+                    </command>
+                    <postProcessing>
+                        <analysisRules>
+                            <item>
+                                <extractorInfo extractorType="regex">
+                                    <extractorProperties type="com.fnfr.svt.mapping.regex.extractors.RegexExtractorPropertyGroup" useLineMode="true">
+                                        <regex>^(\\d+)$</regex>
+                                    </extractorProperties>
+                                </extractorInfo>
+                                <processorInfo ruleType="assert">
+                                    <ruleProperties type="com.fnfr.svt.execution.builtin.processors.AssertionPropertyGroup">
+                                        <expression>$value &gt;= $changeSeconds</expression>
+                                        <actionsWhenTrue>
+                                            <item actionId="Eval">
+                                                <actionProperties type="com.fnfr.svt.execution.builtin.actions.EvalActionPropertyGroup">
+                                                    <statement>set changed 1</statement>
+                                                </actionProperties>
+                                            </item>
+                                        </actionsWhenTrue>
+                                        <actionsWhenFalse>
+                                            <item actionId="Eval">
+                                                <actionProperties type="com.fnfr.svt.execution.builtin.actions.EvalActionPropertyGroup">
+                                                    <statement>set changed 0</statement>
+                                                </actionProperties>
+                                            </item>
+                                        </actionsWhenFalse>
+                                    </ruleProperties>
+                                </processorInfo>
+                            </item>
+                        </analysisRules>
+                    </postProcessing>
+                    <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                </item>
+                <item guid="221d123b-7cbe-429c-8b40-37609bf9619e" action="return">
+                    <command>
+                        <body>$changed</body>
+                    </command>
+                    <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                </item>
+            </steps>
+            <arguments>
+                <item name="uri">
+                    <description>URI of file to check</description>
+                    <isMandatory>true</isMandatory>
+                </item>
+            </arguments>
         </item>
     </procedures>
 </testCase>

--- a/Libraries/Tools/Community/us_flexlm_tools/README.md
+++ b/Libraries/Tools/Community/us_flexlm_tools/README.md
@@ -1,4 +1,8 @@
-# These shell and Tcl scipts are used to manage the APT License Server (FlexLM).
+Project: Flex License Manager Tools
+Description: These shell and Tcl scipts are used to manage the APT License Server (FlexLM).
+Category: automation
+Class: Community
+
 Assumptions: license manager is installed at /usr/local/apt-flexlm
 *	flexlm_check - This script will check various things and let you know what action to take to correct any issues
 *	flexlm_check.tcl - This script is called from flexlm_check

--- a/Libraries/Tools/Community/us_flexlm_tools/documentation/index.html
+++ b/Libraries/Tools/Community/us_flexlm_tools/documentation/index.html
@@ -10,14 +10,18 @@ H1,H2{padding-left:15px}
 .header2Text{font-size:20px; color:darkblue; font-weight:bold; font-family:arial ;text-align:left; padding-left:5px}
 .header3Text{font-size:18px; color:darkblue; font-weight:bold; font-family:arial ;text-align:left; padding-left:10px}
 </style>
-<BR><DIV class='headerText'>These shell and Tcl scipts are used to manage the APT License Server (FlexLM).</DIV>
-<DIV style='margin-left:30px; ' class='normalText'>Assumptions: license manager is installed at /usr/local/apt-flexlm</DIV>
-<DIV style='margin-left:30px; ' class='normalText'>*	flexlm_check - This script will check various things and let you know what action to take to correct any issues</DIV>
-<DIV style='margin-left:30px; ' class='normalText'>*	flexlm_check.tcl - This script is called from flexlm_check</DIV>
-<DIV style='margin-left:30px; ' class='normalText'>*	flexlm_start - This script calls lmgrd with the necessary options</DIV>
-<DIV style='margin-left:30px; ' class='normalText'>*	flexlm_status - This script calls lmutil with the options needed to show the license server status</DIV>
-<DIV style='margin-left:30px; ' class='normalText'>*	flexlm_stop - This script calls lmutil to stop the license server</DIV>
-<DIV style='margin-left:30px; ' class='normalText'>*   setup-env.sh - This script sets up the environment (files, folders, permissions, etc.)</DIV>
+<DIV class='normalText'>Project: Flex License Manager Tools</DIV>
+<DIV class='normalText'>Description: These shell and Tcl scipts are used to manage the APT License Server (FlexLM).</DIV>
+<DIV class='normalText'>Category: automation</DIV>
+<DIV class='normalText'>Class: Community</DIV>
 <DIV style='margin-left:30px; ' class='normalText'><BR></DIV>
-<DIV style='margin-left:30px; ' class='normalText'>Be sure to change permissions on all but the .tcl file to executable.</DIV>
+<DIV class='normalText'>Assumptions: license manager is installed at /usr/local/apt-flexlm</DIV>
+<DIV class='normalText'>*	flexlm_check - This script will check various things and let you know what action to take to correct any issues</DIV>
+<DIV class='normalText'>*	flexlm_check.tcl - This script is called from flexlm_check</DIV>
+<DIV class='normalText'>*	flexlm_start - This script calls lmgrd with the necessary options</DIV>
+<DIV class='normalText'>*	flexlm_status - This script calls lmutil with the options needed to show the license server status</DIV>
+<DIV class='normalText'>*	flexlm_stop - This script calls lmutil to stop the license server</DIV>
+<DIV class='normalText'>*   setup-env.sh - This script sets up the environment (files, folders, permissions, etc.)</DIV>
+<DIV style='margin-left:30px; ' class='normalText'><BR></DIV>
+<DIV class='normalText'>Be sure to change permissions on all but the .tcl file to executable.</DIV>
 <DIV style='margin-left:30px; ' class='normalText'><BR></DIV>

--- a/Libraries/Tools/Community/us_flexlm_tools/documentation/readme.txt
+++ b/Libraries/Tools/Community/us_flexlm_tools/documentation/readme.txt
@@ -1,4 +1,8 @@
-These shell and Tcl scipts are used to manage the APT License Server (FlexLM).
+Project: Flex License Manager Tools
+Description: These shell and Tcl scipts are used to manage the APT License Server (FlexLM).
+Category: automation
+Class: Community
+
 Assumptions: license manager is installed at /usr/local/apt-flexlm
 *	flexlm_check - This script will check various things and let you know what action to take to correct any issues
 *	flexlm_check.tcl - This script is called from flexlm_check


### PR DESCRIPTION
Now supports response map documentation (optional).

Supports changeDate parameter to prevent regeneration of documentation
prior to specified date.

Supports uriDocumentationList parameter. If the specified URI is
present, only document the projects specified within the text file. This
overrides the changeDate parameter.

Displays warning messages for any missing headline or description.

Added documentation to this tool.