### PR TITLE
Using iTest/Velocity to make/restore links for negative testing

### DIFF
--- a/Automation/Community/ai_spirent_demo_assets/.settings/org.eclipse.core.resources.prefs
+++ b/Automation/Community/ai_spirent_demo_assets/.settings/org.eclipse.core.resources.prefs
@@ -1,2 +1,3 @@
 eclipse.preferences.version=1
+encoding//topologies/local/demo.tbml=UTF-8
 encoding//topologies/local/traffic_demo.tbml=UTF-8

--- a/Automation/Community/ai_spirent_demo_assets/META-INF/MANIFEST.MF
+++ b/Automation/Community/ai_spirent_demo_assets/META-INF/MANIFEST.MF
@@ -1,5 +1,5 @@
 Manifest-Version: 1.0
 iTest-Manifest-Version: 1.0
 iTest-Dependent-Project: "di_wireshark_com","di_stc_com","di_Juniper_J
- UNOS","ui_mail_com","di_cisco_ios_com","ui_cmd_com"
+ UNOS","ui_mail_com","di_velocity","di_cisco_ios_com","ui_cmd_com"
 

--- a/Automation/Community/ai_spirent_demo_assets/test_cases/velocity/negative_tests/make_break_example.fftc
+++ b/Automation/Community/ai_spirent_demo_assets/test_cases/velocity/negative_tests/make_break_example.fftc
@@ -1,0 +1,285 @@
+<?xml version="1.0"?>
+<testCase version="7.0.1.201802131446">
+    <general>
+        <documentation>Make/Restore test cases for negative testing</documentation>
+        <notes>You can use this to drive route flapping, LAG testing, ring testing, etc...</notes>
+        <owner>MBarfield</owner>
+    </general>
+    <execution>
+        <parameters version="7.0.1.201802131446">
+            <parameters escape="true">
+                <parameters xmlns:pt="http://www.fnfr.com/schemas/parameterTree">
+                    <linkBreakIterations pt:datatype="INTEGER" pt:description="Number of times to break and restore links">2</linkBreakIterations>
+                    <rowIndex pt:datatype="INTEGER" pt:description="Row that has the linkID to be broken">2</rowIndex>
+                </parameters>
+            </parameters>
+        </parameters>
+    </execution>
+    <testbed>project://ai_spirent_demo_assets/topologies/velocity/logical/JuniperSystemTest.tbml</testbed>
+    <procedures>
+        <item name="main">
+            <steps>
+                <item guid="1cb350ee-5767-4c02-bf61-fc853ebb193b" action="comment">
+                    <command>
+                        <body>Get active reservation</body>
+                    </command>
+                    <nestedSteps>
+                        <item guid="e8f0f2d7-398e-4db5-8cf3-a06d430d6881" action="eval">
+                            <command>
+                                <body>set resvId [velocity reservationId]</body>
+                            </command>
+                            <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                            <useFieldsInCommand>false</useFieldsInCommand>
+                        </item>
+                    </nestedSteps>
+                    <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                    <useFieldsInCommand>false</useFieldsInCommand>
+                </item>
+                <item guid="a0c612cb-7e43-4654-8fcc-05b8eb19b4cd" action="comment">
+                    <command>
+                        <body>Open REST session dynamically findign URL and Token</body>
+                    </command>
+                    <nestedSteps>
+                        <item guid="908cea9a-5224-4cea-a37e-f9eac8ee3fff" action="open" session="vel1">
+                            <command>
+                                <body>device:PC_Shared/PC#Velocity_REST</body>
+                            </command>
+                            <applicationProperties type="com.fnfr.svt.documents.OpenStepPropertyGroup">
+                                <stepProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                                <sessionProperties type="com.fnfr.svt.adapter.automation.tools.common.documents.TransferableDocumentObject" transferableToolId="com.fnfr.itest.applications.webservices.restful" transferableType="com.fnfr.itest.applications.webservices.properties.restful.RESTfulSessionProperties"/>
+                                <sessionClass type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                                <sessionVersion type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                            </applicationProperties>
+                        </item>
+                    </nestedSteps>
+                    <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                    <useFieldsInCommand>false</useFieldsInCommand>
+                </item>
+                <item guid="f0a41aca-5a73-42b5-89f3-f45a39c6415b" action="comment">
+                    <command>
+                        <body>Get topo link info to find urls to break/restore</body>
+                    </command>
+                    <nestedSteps>
+                        <item guid="24a20279-49c5-4f96-819f-da7fa4127d01" action="getTopoLinkInfo" session="vel1">
+                            <command>
+                                <body> -reservationId $resvId</body>
+                            </command>
+                            <postProcessing>
+                                <analysisRules>
+                                    <item>
+                                        <extractorInfo extractorType="query">
+                                            <extractorProperties type="com.fnfr.svt.mapping.execution.extractors.QueryDataExtractorPropertyGroup">
+                                                <query sub="true">(mapped/Tabular/table1/table/row/linkId)\\[[param rowIndex]\\]</query>
+                                            </extractorProperties>
+                                        </extractorInfo>
+                                        <processorInfo ruleType="store">
+                                            <ruleProperties type="com.fnfr.svt.execution.builtin.processors.StoreProcessorPropertyGroup">
+                                                <storageLocation>linkId</storageLocation>
+                                            </ruleProperties>
+                                        </processorInfo>
+                                    </item>
+                                </analysisRules>
+                            </postProcessing>
+                            <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                            <useFieldsInCommand>false</useFieldsInCommand>
+                        </item>
+                        <item guid="9f8cf36d-d023-4813-893b-dc1419d3a2a4" action="getTopoLinkAction" session="vel1">
+                            <command>
+                                <body> -reservationId $resvId -linkId $linkId</body>
+                            </command>
+                            <postProcessing>
+                                <analysisRules>
+                                    <item>
+                                        <extractorInfo extractorType="query">
+                                            <extractorProperties type="com.fnfr.svt.mapping.execution.extractors.QueryDataExtractorPropertyGroup">
+                                                <query>Link_Status()</query>
+                                            </extractorProperties>
+                                        </extractorInfo>
+                                        <processorInfo ruleType="assert">
+                                            <ruleProperties type="com.fnfr.svt.execution.builtin.processors.AssertionPropertyGroup">
+                                                <expression>$value == &quot;ACTIVE&quot;</expression>
+                                                <actionsWhenTrue>
+                                                    <item actionId="DeclareExecutionIssue">
+                                                        <actionProperties type="com.fnfr.svt.execution.builtin.actions.ExecutionIssuePropertyGroup" severity="OK">
+                                                            <message>Verify link is UP; Expected State: ACTIVE, Actual State: $value</message>
+                                                        </actionProperties>
+                                                    </item>
+                                                    <item actionId="PassTestIfNotAlreadyFailed">
+                                                        <actionProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                                                    </item>
+                                                </actionsWhenTrue>
+                                                <actionsWhenFalse>
+                                                    <item actionId="DeclareExecutionIssue">
+                                                        <actionProperties type="com.fnfr.svt.execution.builtin.actions.ExecutionIssuePropertyGroup">
+                                                            <message>Verify link is UP; Expected State: ACTIVE, Actual State: $value</message>
+                                                        </actionProperties>
+                                                    </item>
+                                                    <item actionId="FailTest">
+                                                        <actionProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                                                    </item>
+                                                </actionsWhenFalse>
+                                            </ruleProperties>
+                                        </processorInfo>
+                                    </item>
+                                    <item>
+                                        <extractorInfo extractorType="query">
+                                            <extractorProperties type="com.fnfr.svt.mapping.execution.extractors.QueryDataExtractorPropertyGroup">
+                                                <query>actionUrl_by_actionName(&quot;Break&quot;)</query>
+                                            </extractorProperties>
+                                        </extractorInfo>
+                                        <processorInfo ruleType="store">
+                                            <ruleProperties type="com.fnfr.svt.execution.builtin.processors.StoreProcessorPropertyGroup">
+                                                <storageLocation>breakUrl</storageLocation>
+                                            </ruleProperties>
+                                        </processorInfo>
+                                    </item>
+                                    <item>
+                                        <extractorInfo extractorType="query">
+                                            <extractorProperties type="com.fnfr.svt.mapping.execution.extractors.QueryDataExtractorPropertyGroup">
+                                                <query>actionUrl_by_actionName(&quot;Restore&quot;)</query>
+                                            </extractorProperties>
+                                        </extractorInfo>
+                                        <processorInfo ruleType="store">
+                                            <ruleProperties type="com.fnfr.svt.execution.builtin.processors.StoreProcessorPropertyGroup">
+                                                <storageLocation>restoreUrl</storageLocation>
+                                            </ruleProperties>
+                                        </processorInfo>
+                                    </item>
+                                </analysisRules>
+                            </postProcessing>
+                            <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                            <useFieldsInCommand>false</useFieldsInCommand>
+                        </item>
+                    </nestedSteps>
+                    <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                    <useFieldsInCommand>false</useFieldsInCommand>
+                </item>
+                <item guid="c51e8904-e2b0-4701-a56b-1572d21e0cac" action="comment">
+                    <command>
+                        <body>Loop through break/restore for route flapping and negative testing - parameter used to change iterations</body>
+                    </command>
+                    <nestedSteps>
+                        <item guid="7c4684b0-6494-441f-834a-7c20ca1853cc" action="for">
+                            <command>
+                                <body>{set i 1} {$i &lt;= [param linkBreakIterations]} {incr i}</body>
+                            </command>
+                            <nestedSteps>
+                                <item guid="0624643d-d8ff-46d5-8511-885fd3ccb199" action="comment">
+                                    <command>
+                                        <body>break and make connections</body>
+                                    </command>
+                                    <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                                    <useFieldsInCommand>false</useFieldsInCommand>
+                                </item>
+                                <item guid="19475f6c-c184-4786-88d4-55203d1397f8" action="postAction" session="vel1">
+                                    <command>
+                                        <body> -url $breakUrl -retries 24</body>
+                                    </command>
+                                    <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                                    <useFieldsInCommand>false</useFieldsInCommand>
+                                </item>
+                                <item guid="f1207844-1f46-4681-8b6e-f6fdf8b45cac" action="getTopoLinkAction" session="vel1">
+                                    <command>
+                                        <body> -reservationId $resvId -linkId $linkId</body>
+                                    </command>
+                                    <postProcessing>
+                                        <analysisRules>
+                                            <item>
+                                                <extractorInfo extractorType="query">
+                                                    <extractorProperties type="com.fnfr.svt.mapping.execution.extractors.QueryDataExtractorPropertyGroup">
+                                                        <query>Link_Status()</query>
+                                                    </extractorProperties>
+                                                </extractorInfo>
+                                                <processorInfo ruleType="assert">
+                                                    <ruleProperties type="com.fnfr.svt.execution.builtin.processors.AssertionPropertyGroup">
+                                                        <expression>$value == &quot;INACTIVE&quot;</expression>
+                                                        <actionsWhenTrue>
+                                                            <item actionId="DeclareExecutionIssue">
+                                                                <actionProperties type="com.fnfr.svt.execution.builtin.actions.ExecutionIssuePropertyGroup" severity="OK">
+                                                                    <message>Verify link is DOWN; Expected State: INACTIVE, Actual State: $value</message>
+                                                                </actionProperties>
+                                                            </item>
+                                                            <item actionId="PassTestIfNotAlreadyFailed">
+                                                                <actionProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                                                            </item>
+                                                        </actionsWhenTrue>
+                                                        <actionsWhenFalse>
+                                                            <item actionId="DeclareExecutionIssue">
+                                                                <actionProperties type="com.fnfr.svt.execution.builtin.actions.ExecutionIssuePropertyGroup">
+                                                                    <message>Verify link is DOWN; Expected State: INACTIVE, Actual State: $value</message>
+                                                                </actionProperties>
+                                                            </item>
+                                                            <item actionId="FailTest">
+                                                                <actionProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                                                            </item>
+                                                        </actionsWhenFalse>
+                                                    </ruleProperties>
+                                                </processorInfo>
+                                            </item>
+                                        </analysisRules>
+                                    </postProcessing>
+                                    <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                                    <useFieldsInCommand>false</useFieldsInCommand>
+                                </item>
+                                <item guid="5c42f70d-fb8b-4743-83cb-6ce1ebdf9d84" action="postAction" session="vel1">
+                                    <command>
+                                        <body> -url $restoreUrl -retries 24</body>
+                                    </command>
+                                    <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                                    <useFieldsInCommand>false</useFieldsInCommand>
+                                </item>
+                                <item guid="7151050c-e3b8-4021-b274-52d7a96d1a7d" action="getTopoLinkAction" session="vel1">
+                                    <command>
+                                        <body> -reservationId $resvId -linkId $linkId</body>
+                                    </command>
+                                    <postProcessing>
+                                        <analysisRules>
+                                            <item>
+                                                <extractorInfo extractorType="query">
+                                                    <extractorProperties type="com.fnfr.svt.mapping.execution.extractors.QueryDataExtractorPropertyGroup">
+                                                        <query>Link_Status()</query>
+                                                    </extractorProperties>
+                                                </extractorInfo>
+                                                <processorInfo ruleType="assert">
+                                                    <ruleProperties type="com.fnfr.svt.execution.builtin.processors.AssertionPropertyGroup">
+                                                        <expression>$value == &quot;ACTIVE&quot;</expression>
+                                                        <actionsWhenTrue>
+                                                            <item actionId="DeclareExecutionIssue">
+                                                                <actionProperties type="com.fnfr.svt.execution.builtin.actions.ExecutionIssuePropertyGroup" severity="OK">
+                                                                    <message>Verify link is UP; Expected State: ACTIVE, Actual State: $value</message>
+                                                                </actionProperties>
+                                                            </item>
+                                                            <item actionId="PassTestIfNotAlreadyFailed">
+                                                                <actionProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                                                            </item>
+                                                        </actionsWhenTrue>
+                                                        <actionsWhenFalse>
+                                                            <item actionId="DeclareExecutionIssue">
+                                                                <actionProperties type="com.fnfr.svt.execution.builtin.actions.ExecutionIssuePropertyGroup">
+                                                                    <message>Verify link is UP; Expected State: ACTIVE, Actual State: $value</message>
+                                                                </actionProperties>
+                                                            </item>
+                                                            <item actionId="FailTest">
+                                                                <actionProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                                                            </item>
+                                                        </actionsWhenFalse>
+                                                    </ruleProperties>
+                                                </processorInfo>
+                                            </item>
+                                        </analysisRules>
+                                    </postProcessing>
+                                    <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                                    <useFieldsInCommand>false</useFieldsInCommand>
+                                </item>
+                            </nestedSteps>
+                            <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                            <useFieldsInCommand>false</useFieldsInCommand>
+                        </item>
+                    </nestedSteps>
+                    <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                    <useFieldsInCommand>false</useFieldsInCommand>
+                </item>
+            </steps>
+        </item>
+    </procedures>
+</testCase>

--- a/Libraries/Tools/di_velocity_com/.gitignore
+++ b/Libraries/Tools/di_velocity_com/.gitignore
@@ -1,0 +1,3 @@
+/.formmaplib.fffmcat
+/.maplib.ffrmcat
+/.testcaselib.fftccat

--- a/Libraries/Tools/di_velocity_com/.project
+++ b/Libraries/Tools/di_velocity_com/.project
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>di_velocity_com</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>com.fnfr.svt.builders.documents.svtdocumentsbuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>com.spirent.itest.security.assets.ui.SignatureVerificationBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>com.fnfr.svt.builders.documents.svtdocumentsnature</nature>
+		<nature>com.fnfr.svt.formmapping.formmaplibrarynature</nature>
+		<nature>com.fnfr.svt.mapping.maplibrarynature</nature>
+		<nature>com.spirent.itest.security.assets.ui.SecurityNature</nature>
+	</natures>
+</projectDescription>

--- a/Libraries/Tools/di_velocity_com/META-INF/MANIFEST.MF
+++ b/Libraries/Tools/di_velocity_com/META-INF/MANIFEST.MF
@@ -1,0 +1,4 @@
+Manifest-Version: 1.0
+iTest-Manifest-Version: 1.0
+iTest-Dependent-Project: 
+

--- a/Libraries/Tools/di_velocity_com/response_maps/quickCalls/getTopoLinkAction.ffrm
+++ b/Libraries/Tools/di_velocity_com/response_maps/quickCalls/getTopoLinkAction.ffrm
@@ -1,0 +1,94 @@
+<?xml version="1.0"?>
+<ResponseMap version="7.0.1.201802131446">
+    <sampleDictionary>
+        <item name="sample1">
+            <action actionType="getTopoLinkAction">
+                <command>
+                    <body> -reservationId $reservationId -token $token -linkId $linkId</body>
+                </command>
+            </action>
+            <responseBody>Link Status: ACTIVE
+
+actionName,actionType,actionUrl
+Break,HTTP_POST,https://10.108.36.207/velocity/api/reservation/v2/reservation/5da69c93-af49-412d-a3ba-b933b1e49dbf/link/ib5eada78-09f1-454d-a851-363dbea41d34/break
+Restore,HTTP_POST,https://10.108.36.207/velocity/api/reservation/v2/reservation/5da69c93-af49-412d-a3ba-b933b1e49dbf/link/ib5eada78-09f1-454d-a851-363dbea41d34/restore
+</responseBody>
+            <contentType>text</contentType>
+            <structuredData>
+&lt;structure xmlns:map=&quot;http://www.fnfr.com/svt/mapping&quot;&gt;
+    &lt;isEmpty&gt;false&lt;/isEmpty&gt;
+    &lt;definedIn&gt;project://di_velocity/session_profiles/REST_ref_session_profile_quickcall_library.fftc&lt;/definedIn&gt;
+&lt;/structure&gt;
+</structuredData>
+            <aliases>
+                <item name="isEmpty">
+                    <queryFormatString>.//isEmpty</queryFormatString>
+                </item>
+                <item name="definedIn">
+                    <queryFormatString>.//definedIn</queryFormatString>
+                    <source>Kernel</source>
+                </item>
+            </aliases>
+            <duration>2.8</duration>
+        </item>
+    </sampleDictionary>
+    <mapperProperties>
+        <item type="com.fnfr.svt.mapping.table.TabularMapperProperties">
+            <tabularMaps>
+                <item name="table1">
+                    <banner>actionName,actionType,actionUrl</banner>
+                    <bannerStructure>Wildcard</bannerStructure>
+                    <delimiter>Comma</delimiter>
+                    <columns>
+                        <item name="actionName">
+                            <isKey>true</isKey>
+                            <lastFullCell></lastFullCell>
+                            <uid>c553e4e2-ec3b-4a9a-ae20-767d2c9c1d1d</uid>
+                        </item>
+                        <item name="actionType">
+                            <lastFullCell></lastFullCell>
+                            <uid>2185d6d4-f46b-4e20-8051-01183484ea4d</uid>
+                        </item>
+                        <item name="actionUrl">
+                            <lastFullCell></lastFullCell>
+                            <uid>df295b69-229c-4a23-808f-712a56ebd0a4</uid>
+                        </item>
+                    </columns>
+                </item>
+            </tabularMaps>
+        </item>
+        <item type="com.fnfr.svt.mapping.regex.RegexMapperProperties">
+            <regexMaps>
+                <item name="pattern1">
+                    <groups>
+                        <item name="anchor0">
+                            <regex>Link Status:\\s+</regex>
+                            <start>0</start>
+                            <end>13</end>
+                        </item>
+                        <item name="Link_Status">
+                            <regex>\\w+</regex>
+                            <named>true</named>
+                            <start>13</start>
+                            <end>19</end>
+                            <suggestions>
+                                <item name=".+">one or more of any character</item>
+                                <item name="[^\r\n]+">one or more of any character except line endings</item>
+                                <item name="[^0-9\r\n]+">one or more non-digit characters except line endings</item>
+                                <item name="\S+">one or more non-whitespace characters</item>
+                                <item name="\w+">one or more word characters</item>
+                            </suggestions>
+                        </item>
+                    </groups>
+                    <sampleMatch>Link Status: ACTIVE</sampleMatch>
+                    <regexMapMode>Line</regexMapMode>
+                </item>
+            </regexMaps>
+        </item>
+    </mapperProperties>
+    <applicabilityProperties actionType="getTopoLinkAction" command="-reservationId * -linkId *">
+        <application>
+            <item>com.fnfr.itest.applications.webservices.restful</item>
+        </application>
+    </applicabilityProperties>
+</ResponseMap>

--- a/Libraries/Tools/di_velocity_com/response_maps/quickCalls/getTopoLinkInfo.ffrm
+++ b/Libraries/Tools/di_velocity_com/response_maps/quickCalls/getTopoLinkInfo.ffrm
@@ -1,0 +1,73 @@
+<?xml version="1.0"?>
+<ResponseMap version="7.0.1.201802131446">
+    <sampleDictionary>
+        <item name="sample1">
+            <action actionType="getTopoLinkInfo">
+                <command>
+                    <body> -reservationId 5da69c93-af49-412d-a3ba-b933b1e49dbf -token eyJwYWNrZXQiOiAie1wiZXhwaXJhdGlvblwiOiAxNTI2NDI1ODc0LCBcInVzZXJfbmFtZVwiOiBcIk1pa2UgQmFyZmllbGRcIiwgXCJkb21haW5cIjogXCJsZGFwXCIsIFwic3RhcnRfdGltZVwiOiAxNTI2NDE3NDc0LCBcImlkXCI6IFwibWJhcmZpZWxkXCJ9IiwgInNpZ25hdHVyZSI6ICIzM2E2NDQyNGZmZGNlNjViYzdmOTVkNTc1M2E4NmY5MGE3MTAzNDYxNTkyZDA5MDNhZTEwYmViNmVmNTUyY2ExMzY4YzU5MTg4YzFjZTY4YjJmMTg3NGViM2ZlOThhMzE3MTYwMDU0NmVhM2FmZWJkNjcxMWU0Y2NjMjUyNjQxOGIxYzU4Nzc4ZDk0YTY1YmRmMzZmODUxZGVkMjM0ZmMyZjVhNmI3MjUyYjk5ZDA2ZGI4MTNlZTMzYzBhMGZhOGYwOTA3ZGU3ODkyOTA3YWMyNmRhM2IwZWNhMTgwMzhjYmQ2MzMxM2EzNWM0MjQ3M2E1MDNhZDE5ZjFmYzBjMzc1ZjU2OWEyNWRiYTIwM2I5MjJjZjQ2MjE5MTk4NjZiNGQ5MjA5YTQzZWNhMTA4MDlkNjE2MGQ3ZWE0ZDcxYmMxZDNmZjA0MGM3NWE3YWNiZDJhNDM5NDlkNDY3ZmI1YTgxMzhlYmZjMTExZWNlYzRkZWZlOWRjZTA0ZjYwNDI4YmZkYzUzNjVjY2JjZTY1ZjM3YmVkOWVhNTgyYzhmNWI5Y2YyOTMyYjkxOTYzYWI5YjU2NzQ0N2VhNjBiYTgyYmIzM2NmZjIzYzU3ZDRkNTFmOTQ1YjFiMDFlYmVlZjViZmE2MjUxMjJiZTM5YjVmMTA2YjliMGQwODJkNzc2NDU5OSJ9</body>
+                </command>
+            </action>
+            <responseBody>linkId,endPointOne,resourceOne,endPointTwo,resourceTwo
+ib5eada78-09f1-454d-a851-363dbea41d34,FastEthernet6/0,Router1,FastEthernet6/0,Router2
+icb5d9a7d-ae4d-45b5-ac37-84604fd3b1ad,2/11,STC1,FastEthernet5/0,Router1
+i8b8e40e6-2d91-49a1-a6e0-84264fa69e34,2/12,STC1,FastEthernet5/0,Router2
+</responseBody>
+            <contentType>text</contentType>
+            <structuredData>
+&lt;structure xmlns:map=&quot;http://www.fnfr.com/svt/mapping&quot;&gt;
+    &lt;isEmpty&gt;false&lt;/isEmpty&gt;
+    &lt;definedIn&gt;project://di_velocity/session_profiles/REST_ref_session_profile_quickcall_library.fftc&lt;/definedIn&gt;
+&lt;/structure&gt;
+</structuredData>
+            <aliases>
+                <item name="isEmpty">
+                    <queryFormatString>.//isEmpty</queryFormatString>
+                </item>
+                <item name="definedIn">
+                    <queryFormatString>.//definedIn</queryFormatString>
+                    <source>Kernel</source>
+                </item>
+            </aliases>
+            <duration>3.8</duration>
+        </item>
+    </sampleDictionary>
+    <mapperProperties>
+        <item type="com.fnfr.svt.mapping.table.TabularMapperProperties">
+            <tabularMaps>
+                <item name="table1">
+                    <banner>linkId,endPointOne,resourceOne,endPointTwo,resourceTwo</banner>
+                    <bannerStructure>Wildcard</bannerStructure>
+                    <delimiter>Comma</delimiter>
+                    <columns>
+                        <item name="linkId">
+                            <isKey>true</isKey>
+                            <lastFullCell></lastFullCell>
+                            <uid>b539fe7c-f32f-4079-83e1-3cf7ce2555a4</uid>
+                        </item>
+                        <item name="endPointOne">
+                            <lastFullCell></lastFullCell>
+                            <uid>4fcdc0a3-7b13-4d16-aff4-de8654781b2c</uid>
+                        </item>
+                        <item name="resourceOne">
+                            <lastFullCell></lastFullCell>
+                            <uid>e0bb8927-febf-481b-b08a-fef09a511669</uid>
+                        </item>
+                        <item name="endPointTwo">
+                            <lastFullCell></lastFullCell>
+                            <uid>f92b9690-21e8-48eb-bc6a-0bcae5e8bcf6</uid>
+                        </item>
+                        <item name="resourceTwo">
+                            <lastFullCell></lastFullCell>
+                            <uid>91e7dbe5-4287-43e9-badf-85f584fb3425</uid>
+                        </item>
+                    </columns>
+                </item>
+            </tabularMaps>
+        </item>
+    </mapperProperties>
+    <applicabilityProperties actionType="getTopoLinkInfo" command="-reservationId *">
+        <application>
+            <item>com.fnfr.itest.applications.webservices.restful</item>
+        </application>
+    </applicabilityProperties>
+</ResponseMap>

--- a/Libraries/Tools/di_velocity_com/session_profiles/REST_ref_session_profile.ffsp
+++ b/Libraries/Tools/di_velocity_com/session_profiles/REST_ref_session_profile.ffsp
@@ -1,0 +1,36 @@
+<?xml version="1.0"?>
+<SessionTemplate version="7.0.1.201802131446">
+    <baseApplication>com.fnfr.itest.applications.webservices.restful</baseApplication>
+    <sessionProperties type="com.fnfr.svt.adapter.automation.tools.common.documents.TransferableDocumentObject" transferableToolId="com.fnfr.itest.applications.webservices.restful" transferableType="com.fnfr.itest.applications.webservices.properties.restful.RESTfulSessionProperties" url="https://10.108.36.207/velocity/api" url.inherit="false">
+        <authentication transferableToolId="com.fnfr.itest.applications.webservices.restful" transferableType="com.fnfr.itest.applications.webservices.properties.AuthenticationProperties" authenticationType.inherit="false" acceptAllCertificates="true" acceptAllCertificates.inherit="false"/>
+        <httpHeader inherit="false" transferableToolId="com.fnfr.itest.applications.webservices.restful">
+            <memberClasses>
+                <item>com.fnfr.itest.applications.webservices.properties.HTTPHeaderEntry</item>
+            </memberClasses>
+            <item transferableToolId="com.fnfr.itest.applications.webservices.restful" transferableType="com.fnfr.itest.applications.webservices.properties.HTTPHeaderEntry" header="Content-Type" header.inherit="false" value="application/json" value.inherit="false"/>
+            <item transferableToolId="com.fnfr.itest.applications.webservices.restful" transferableType="com.fnfr.itest.applications.webservices.properties.HTTPHeaderEntry" header="X-Auth-Token" header.inherit="false" value="[velocity token]" value.inherit="false"/>
+        </httpHeader>
+        <httpHeaderTemplate inherit="false" transferableToolId="com.fnfr.itest.applications.webservices.restful">
+            <memberClasses>
+                <item>com.fnfr.itest.applications.webservices.properties.HTTPHeaderEntry</item>
+            </memberClasses>
+            <item transferableToolId="com.fnfr.itest.applications.webservices.restful" transferableType="com.fnfr.itest.applications.webservices.properties.HTTPHeaderEntry" header="Content-Type" header.inherit="false" value="application/json" value.inherit="false"/>
+            <item transferableToolId="com.fnfr.itest.applications.webservices.restful" transferableType="com.fnfr.itest.applications.webservices.properties.HTTPHeaderEntry" header="Cookie" header.inherit="false" value="x" value.inherit="false"/>
+            <item transferableToolId="com.fnfr.itest.applications.webservices.restful" transferableType="com.fnfr.itest.applications.webservices.properties.HTTPHeaderEntry" header="X-Auth-Token" header.inherit="false"/>
+        </httpHeaderTemplate>
+    </sessionProperties>
+    <parameters version="7.0.1.201802131446">
+        <parameters escape="true">
+            <parameters xmlns:pt="http://www.fnfr.com/schemas/parameterTree">
+                <username pt:description="Valid username">mbarfield</username>
+                <password pt:description="valid password" pt:mask="true">ECfyV0EM6mvwammPrSnywg==</password>
+            </parameters>
+        </parameters>
+    </parameters>
+    <responseLibrary inherit="false">project://di_velocity/</responseLibrary>
+    <sessionClassTestCase inherit="false">project://di_velocity_com/session_profiles/REST_ref_session_profile_quickcall_library.fftc</sessionClassTestCase>
+    <nickName>velocity_api</nickName>
+    <Overview>Velocity RESTful session</Overview>
+    <Description>This session can be used with iTest or as a standalone session but you will need to get the token id or use basic authentication</Description>
+    <isReferenceProfile>true</isReferenceProfile>
+</SessionTemplate>

--- a/Libraries/Tools/di_velocity_com/session_profiles/REST_ref_session_profile_quickcall_library.fftc
+++ b/Libraries/Tools/di_velocity_com/session_profiles/REST_ref_session_profile_quickcall_library.fftc
@@ -1,0 +1,569 @@
+<?xml version="1.0"?>
+<testCase version="7.0.1.201802131446">
+    <general>
+        <isProcedureLibrary>true</isProcedureLibrary>
+        <sessionClass includeTestCase="true" sessionType="project://di_velocity_com/session_profiles/REST_ref_session_profile.ffsp"/>
+    </general>
+    <procedures>
+        <item name="main">
+            <steps>
+                <item guid="941806ee-c8e3-474f-bef5-3007e895f8f5" action="comment">
+                    <command>
+                        <body>main - not used</body>
+                    </command>
+                    <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                    <useFieldsInCommand>false</useFieldsInCommand>
+                </item>
+            </steps>
+        </item>
+        <item name="getTopoLinkInfo" isPublic="true">
+            <description>Get link info - useful for make/break testing</description>
+            <steps>
+                <item guid="f9c66566-697e-4722-8556-fabcfb24e68a" action="GET" session="$session">
+                    <command>
+                        <body>/velocity/api/reservation/v9/reservation/$reservationId/topology/links</body>
+                    </command>
+                    <postProcessing>
+                        <analysisRules>
+                            <item>
+                                <extractorInfo extractorType="query">
+                                    <extractorProperties type="com.fnfr.svt.mapping.execution.extractors.QueryDataExtractorPropertyGroup">
+                                        <query>count(.//item)</query>
+                                    </extractorProperties>
+                                </extractorInfo>
+                                <processorInfo ruleType="store">
+                                    <ruleProperties type="com.fnfr.svt.execution.builtin.processors.StoreProcessorPropertyGroup">
+                                        <storageLocation>linkCount</storageLocation>
+                                    </ruleProperties>
+                                </processorInfo>
+                            </item>
+                        </analysisRules>
+                        <storeResponseAt>topoLinks</storeResponseAt>
+                    </postProcessing>
+                    <applicationProperties type="com.fnfr.svt.adapter.automation.tools.common.documents.TransferableDocumentObject" transferableToolId="com.fnfr.itest.applications.webservices.restful" transferableType="com.fnfr.itest.applications.webservices.properties.restful.RESTfulInvokeProperties" action="/velocity/api/reservation/v9/reservation/$reservationId/topology/links" action.inherit="false"/>
+                    <emulation>
+                        <behavior>
+                            <response>{&quot;links&quot;:[{&quot;id&quot;:&quot;ib5eada78-09f1-454d-a851-363dbea41d34&quot;,&quot;isPortLink&quot;:true,&quot;resource1&quot;:{&quot;id&quot;:&quot;i8684ee1e-ce53-4f24-9c50-d4e70ea30419&quot;,&quot;name&quot;:&quot;FastEthernet6/0&quot;,&quot;parentId&quot;:&quot;i88e94c90-0fe2-4cf0-b418-9f1063c48f5a&quot;,&quot;inventoryResourceId&quot;:&quot;e472b239-d090-4178-ac80-04d2e5a04418&quot;,&quot;originalId&quot;:&quot;i8684ee1e-ce53-4f24-9c50-d4e70ea30419&quot;,&quot;condition&quot;:null,&quot;problemCode&quot;:null},&quot;parentResource1&quot;:{&quot;id&quot;:&quot;i88e94c90-0fe2-4cf0-b418-9f1063c48f5a&quot;,&quot;name&quot;:&quot;Router1&quot;,&quot;parentId&quot;:null,&quot;inventoryResourceId&quot;:&quot;43ec0dde-d8b6-49d4-93b9-db7b147a04f1&quot;,&quot;originalId&quot;:&quot;i88e94c90-0fe2-4cf0-b418-9f1063c48f5a&quot;,&quot;condition&quot;:null,&quot;problemCode&quot;:null},&quot;resource2&quot;:{&quot;id&quot;:&quot;i9323ec37-8a48-45d4-ab60-44a406df6159&quot;,&quot;name&quot;:&quot;FastEthernet6/0&quot;,&quot;parentId&quot;:&quot;i59e4a3e6-8550-448a-b66e-b4c08dded753&quot;,&quot;inventoryResourceId&quot;:&quot;cba3b892-e6e7-4ae8-a9c7-52f2fe9dc010&quot;,&quot;originalId&quot;:&quot;i9323ec37-8a48-45d4-ab60-44a406df6159&quot;,&quot;condition&quot;:null,&quot;problemCode&quot;:null},&quot;parentResource2&quot;:{&quot;id&quot;:&quot;i59e4a3e6-8550-448a-b66e-b4c08dded753&quot;,&quot;name&quot;:&quot;Router2&quot;,&quot;parentId&quot;:null,&quot;inventoryResourceId&quot;:&quot;f45dfdde-b8d8-4396-bbb0-e6ef43f747b5&quot;,&quot;originalId&quot;:&quot;i59e4a3e6-8550-448a-b66e-b4c08dded753&quot;,&quot;condition&quot;:null,&quot;problemCode&quot;:null},&quot;bidirectional&quot;:true,&quot;connectionTypeName&quot;:&quot;Ethernet&quot;,&quot;condition&quot;:&quot;&quot;,&quot;problemCode&quot;:null,&quot;connections&quot;:[]},{&quot;id&quot;:&quot;icb5d9a7d-ae4d-45b5-ac37-84604fd3b1ad&quot;,&quot;isPortLink&quot;:true,&quot;resource1&quot;:{&quot;id&quot;:&quot;i8dd38094-cd56-4992-ab5f-1cb94f9d2a44&quot;,&quot;name&quot;:&quot;2/11&quot;,&quot;parentId&quot;:&quot;i583b18d9-6492-43e6-80bb-b0a0eb77f0d3&quot;,&quot;inventoryResourceId&quot;:&quot;b0ddad53-2a55-48eb-ba69-9e49e56e3bac&quot;,&quot;originalId&quot;:&quot;i8dd38094-cd56-4992-ab5f-1cb94f9d2a44&quot;,&quot;condition&quot;:null,&quot;problemCode&quot;:null},&quot;parentResource1&quot;:{&quot;id&quot;:&quot;i583b18d9-6492-43e6-80bb-b0a0eb77f0d3&quot;,&quot;name&quot;:&quot;STC1&quot;,&quot;parentId&quot;:null,&quot;inventoryResourceId&quot;:&quot;ab715126-4659-4e7a-a2ac-c5a689196b60&quot;,&quot;originalId&quot;:&quot;i583b18d9-6492-43e6-80bb-b0a0eb77f0d3&quot;,&quot;condition&quot;:null,&quot;problemCode&quot;:null},&quot;resource2&quot;:{&quot;id&quot;:&quot;i54eb92e5-2ded-46ba-b774-e49d347eee21&quot;,&quot;name&quot;:&quot;FastEthernet5/0&quot;,&quot;parentId&quot;:&quot;i88e94c90-0fe2-4cf0-b418-9f1063c48f5a&quot;,&quot;inventoryResourceId&quot;:&quot;ff20e2db-a776-4028-a799-87f4edf2a087&quot;,&quot;originalId&quot;:&quot;i54eb92e5-2ded-46ba-b774-e49d347eee21&quot;,&quot;condition&quot;:null,&quot;problemCode&quot;:null},&quot;parentResource2&quot;:{&quot;id&quot;:&quot;i88e94c90-0fe2-4cf0-b418-9f1063c48f5a&quot;,&quot;name&quot;:&quot;Router1&quot;,&quot;parentId&quot;:null,&quot;inventoryResourceId&quot;:&quot;43ec0dde-d8b6-49d4-93b9-db7b147a04f1&quot;,&quot;originalId&quot;:&quot;i88e94c90-0fe2-4cf0-b418-9f1063c48f5a&quot;,&quot;condition&quot;:null,&quot;problemCode&quot;:null},&quot;bidirectional&quot;:true,&quot;connectionTypeName&quot;:&quot;Ethernet&quot;,&quot;condition&quot;:&quot;&quot;,&quot;problemCode&quot;:null,&quot;connections&quot;:[]},{&quot;id&quot;:&quot;i8b8e40e6-2d91-49a1-a6e0-84264fa69e34&quot;,&quot;isPortLink&quot;:true,&quot;resource1&quot;:{&quot;id&quot;:&quot;i15b51f3a-a561-4024-9f01-a8c8d53712e7&quot;,&quot;name&quot;:&quot;2/12&quot;,&quot;parentId&quot;:&quot;i583b18d9-6492-43e6-80bb-b0a0eb77f0d3&quot;,&quot;inventoryResourceId&quot;:&quot;5ce04128-cece-424a-92b8-5b064249d4ec&quot;,&quot;originalId&quot;:&quot;i15b51f3a-a561-4024-9f01-a8c8d53712e7&quot;,&quot;condition&quot;:null,&quot;problemCode&quot;:null},&quot;parentResource1&quot;:{&quot;id&quot;:&quot;i583b18d9-6492-43e6-80bb-b0a0eb77f0d3&quot;,&quot;name&quot;:&quot;STC1&quot;,&quot;parentId&quot;:null,&quot;inventoryResourceId&quot;:&quot;ab715126-4659-4e7a-a2ac-c5a689196b60&quot;,&quot;originalId&quot;:&quot;i583b18d9-6492-43e6-80bb-b0a0eb77f0d3&quot;,&quot;condition&quot;:null,&quot;problemCode&quot;:null},&quot;resource2&quot;:{&quot;id&quot;:&quot;i28e39bad-5bfd-4c93-8587-d13fe5c6a224&quot;,&quot;name&quot;:&quot;FastEthernet5/0&quot;,&quot;parentId&quot;:&quot;i59e4a3e6-8550-448a-b66e-b4c08dded753&quot;,&quot;inventoryResourceId&quot;:&quot;1ce78989-e998-4ed5-ae6d-475ee92796a9&quot;,&quot;originalId&quot;:&quot;i28e39bad-5bfd-4c93-8587-d13fe5c6a224&quot;,&quot;condition&quot;:null,&quot;problemCode&quot;:null},&quot;parentResource2&quot;:{&quot;id&quot;:&quot;i59e4a3e6-8550-448a-b66e-b4c08dded753&quot;,&quot;name&quot;:&quot;Router2&quot;,&quot;parentId&quot;:null,&quot;inventoryResourceId&quot;:&quot;f45dfdde-b8d8-4396-bbb0-e6ef43f747b5&quot;,&quot;originalId&quot;:&quot;i59e4a3e6-8550-448a-b66e-b4c08dded753&quot;,&quot;condition&quot;:null,&quot;problemCode&quot;:null},&quot;bidirectional&quot;:true,&quot;connectionTypeName&quot;:&quot;Ethernet&quot;,&quot;condition&quot;:&quot;&quot;,&quot;problemCode&quot;:null,&quot;connections&quot;:[]}]}</response>
+                            <responseType>text</responseType>
+                            <structuredData>
+&lt;structure xmlns:map=&quot;http://www.fnfr.com/svt/mapping&quot;&gt;
+    &lt;statusCode value=&quot;200&quot;/&gt;
+    &lt;requestHTTPHeaders map:nodetype=&quot;token&quot;&gt;
+        &lt;Content_Type map:nodetype=&quot;token&quot;&gt;application/json&lt;/Content_Type&gt;
+        &lt;X_Auth_Token map:nodetype=&quot;token&quot;&gt;eyJwYWNrZXQiOiAie1wiZXhwaXJhdGlvblwiOiAxNTI2NDkyODI0LCBcInVzZXJfbmFtZVwiOiBcIk1pa2UgQmFyZmllbGRcIiwgXCJkb21haW5cIjogXCJsZGFwXCIsIFwic3RhcnRfdGltZVwiOiAxNTI2NDA1MjI0LCBcImlkXCI6IFwibWJhcmZpZWxkXCJ9IiwgInNpZ25hdHVyZSI6ICI0ZDc2ZWU0Zjk5MTAyMWEyYmRhNzY4NmQxNGIxYzEyNzJjOGVmMzBmOTI0NWNjOTFkZDQyOWViZTQ3YWM0MmI1ZjRiZGE1MjYxZDY3YTExMTI3NTg3MGQxZTU5NmRjNjliZTM0OTc1NzdmMjJlZDhmNjYzNTVjYzE3NzllZTAzNGI5ODVjOWYzOTJlMjIyZGYxMjQzNjE2MTdmMWQxODNkZmRkNzdkNjVhOGRhNjQ3ODhlNjQ2ZjQwMjA0NDlhZjViNmZhZmEzNzEzYTFmNjQ1NTIxNzBkYmNjOWJlNGFlZmFlODg5OWYzNWI5ODg4NGUzNGYzZjMxZjgyYTE5YmMyMzUwYzcyMjdiMTU3MjQ3ZGRiNjc3NTFhOWI1NzMyYmMyYmRjNjdiZDFmOWEwNTZjYTMzYWZjYmVkOTRjMWY0YTQ2MDUzNTIzZjNiNWEwYjdlNjA2NTE2ZjYxNTcyYTg1MTJmM2U4ZjcxNWUxZjM3N2QwZWVhZjkyNjFiMmNjMjU3MTc3OWRhMjIxZDEyMWU5MjMzNTc5ZWQ4MGZiYjA3YjA5NTQ5ODhmNjhmMzRkZjdkMzgzMmIxMzMzODUzZDg3ZDM5N2JjZDhjYWIxMDJiN2QxNzg3ODM2NTdiN2E3MDIzMjkwODFhMDFjNmM1M2NhM2U3MTdhYzUwNTEwZWExMCJ9&lt;/X_Auth_Token&gt;
+    &lt;/requestHTTPHeaders&gt;
+    &lt;requestRawText map:nodetype=&quot;token&quot;/&gt;
+    &lt;responseHTTPHeaders map:nodetype=&quot;token&quot;&gt;
+        &lt;Server map:nodetype=&quot;token&quot;&gt;nginx/1.10.3 (Ubuntu)&lt;/Server&gt;
+        &lt;Cache_Control map:nodetype=&quot;token&quot;&gt;no-cache, no-store, must-revalidate&lt;/Cache_Control&gt;
+        &lt;Cache_Control map:nodetype=&quot;token&quot;&gt;no-cache&lt;/Cache_Control&gt;
+        &lt;Connection map:nodetype=&quot;token&quot;&gt;keep-alive&lt;/Connection&gt;
+        &lt;Expires map:nodetype=&quot;token&quot;&gt;0&lt;/Expires&gt;
+        &lt;Pragma map:nodetype=&quot;token&quot;&gt;no-cache&lt;/Pragma&gt;
+        &lt;Content_Length map:nodetype=&quot;token&quot;&gt;3688&lt;/Content_Length&gt;
+        &lt;Date map:nodetype=&quot;token&quot;&gt;Tue, 15 May 2018 17:47:06 GMT&lt;/Date&gt;
+        &lt;Content_Type map:nodetype=&quot;token&quot;&gt;application/json&lt;/Content_Type&gt;
+        &lt;X_Powered_By map:nodetype=&quot;token&quot;&gt;Undertow/1&lt;/X_Powered_By&gt;
+    &lt;/responseHTTPHeaders&gt;
+    &lt;responseRawText map:nodetype=&quot;token&quot;&gt;{&amp;quot;links&amp;quot;:[{&amp;quot;id&amp;quot;:&amp;quot;ib5eada78-09f1-454d-a851-363dbea41d34&amp;quot;,&amp;quot;isPortLink&amp;quot;:true,&amp;quot;resource1&amp;quot;:{&amp;quot;id&amp;quot;:&amp;quot;i8684ee1e-ce53-4f24-9c50-d4e70ea30419&amp;quot;,&amp;quot;name&amp;quot;:&amp;quot;FastEthernet6/0&amp;quot;,&amp;quot;parentId&amp;quot;:&amp;quot;i88e94c90-0fe2-4cf0-b418-9f1063c48f5a&amp;quot;,&amp;quot;inventoryResourceId&amp;quot;:&amp;quot;e472b239-d090-4178-ac80-04d2e5a04418&amp;quot;,&amp;quot;originalId&amp;quot;:&amp;quot;i8684ee1e-ce53-4f24-9c50-d4e70ea30419&amp;quot;,&amp;quot;condition&amp;quot;:null,&amp;quot;problemCode&amp;quot;:null},&amp;quot;parentResource1&amp;quot;:{&amp;quot;id&amp;quot;:&amp;quot;i88e94c90-0fe2-4cf0-b418-9f1063c48f5a&amp;quot;,&amp;quot;name&amp;quot;:&amp;quot;Router1&amp;quot;,&amp;quot;parentId&amp;quot;:null,&amp;quot;inventoryResourceId&amp;quot;:&amp;quot;43ec0dde-d8b6-49d4-93b9-db7b147a04f1&amp;quot;,&amp;quot;originalId&amp;quot;:&amp;quot;i88e94c90-0fe2-4cf0-b418-9f1063c48f5a&amp;quot;,&amp;quot;condition&amp;quot;:null,&amp;quot;problemCode&amp;quot;:null},&amp;quot;resource2&amp;quot;:{&amp;quot;id&amp;quot;:&amp;quot;i9323ec37-8a48-45d4-ab60-44a406df6159&amp;quot;,&amp;quot;name&amp;quot;:&amp;quot;FastEthernet6/0&amp;quot;,&amp;quot;parentId&amp;quot;:&amp;quot;i59e4a3e6-8550-448a-b66e-b4c08dded753&amp;quot;,&amp;quot;inventoryResourceId&amp;quot;:&amp;quot;cba3b892-e6e7-4ae8-a9c7-52f2fe9dc010&amp;quot;,&amp;quot;originalId&amp;quot;:&amp;quot;i9323ec37-8a48-45d4-ab60-44a406df6159&amp;quot;,&amp;quot;condition&amp;quot;:null,&amp;quot;problemCode&amp;quot;:null},&amp;quot;parentResource2&amp;quot;:{&amp;quot;id&amp;quot;:&amp;quot;i59e4a3e6-8550-448a-b66e-b4c08dded753&amp;quot;,&amp;quot;name&amp;quot;:&amp;quot;Router2&amp;quot;,&amp;quot;parentId&amp;quot;:null,&amp;quot;inventoryResourceId&amp;quot;:&amp;quot;f45dfdde-b8d8-4396-bbb0-e6ef43f747b5&amp;quot;,&amp;quot;originalId&amp;quot;:&amp;quot;i59e4a3e6-8550-448a-b66e-b4c08dded753&amp;quot;,&amp;quot;condition&amp;quot;:null,&amp;quot;problemCode&amp;quot;:null},&amp;quot;bidirectional&amp;quot;:true,&amp;quot;connectionTypeName&amp;quot;:&amp;quot;Ethernet&amp;quot;,&amp;quot;condition&amp;quot;:&amp;quot;&amp;quot;,&amp;quot;problemCode&amp;quot;:null,&amp;quot;connections&amp;quot;:[]},{&amp;quot;id&amp;quot;:&amp;quot;icb5d9a7d-ae4d-45b5-ac37-84604fd3b1ad&amp;quot;,&amp;quot;isPortLink&amp;quot;:true,&amp;quot;resource1&amp;quot;:{&amp;quot;id&amp;quot;:&amp;quot;i8dd38094-cd56-4992-ab5f-1cb94f9d2a44&amp;quot;,&amp;quot;name&amp;quot;:&amp;quot;2/11&amp;quot;,&amp;quot;parentId&amp;quot;:&amp;quot;i583b18d9-6492-43e6-80bb-b0a0eb77f0d3&amp;quot;,&amp;quot;inventoryResourceId&amp;quot;:&amp;quot;b0ddad53-2a55-48eb-ba69-9e49e56e3bac&amp;quot;,&amp;quot;originalId&amp;quot;:&amp;quot;i8dd38094-cd56-4992-ab5f-1cb94f9d2a44&amp;quot;,&amp;quot;condition&amp;quot;:null,&amp;quot;problemCode&amp;quot;:null},&amp;quot;parentResource1&amp;quot;:{&amp;quot;id&amp;quot;:&amp;quot;i583b18d9-6492-43e6-80bb-b0a0eb77f0d3&amp;quot;,&amp;quot;name&amp;quot;:&amp;quot;STC1&amp;quot;,&amp;quot;parentId&amp;quot;:null,&amp;quot;inventoryResourceId&amp;quot;:&amp;quot;ab715126-4659-4e7a-a2ac-c5a689196b60&amp;quot;,&amp;quot;originalId&amp;quot;:&amp;quot;i583b18d9-6492-43e6-80bb-b0a0eb77f0d3&amp;quot;,&amp;quot;condition&amp;quot;:null,&amp;quot;problemCode&amp;quot;:null},&amp;quot;resource2&amp;quot;:{&amp;quot;id&amp;quot;:&amp;quot;i54eb92e5-2ded-46ba-b774-e49d347eee21&amp;quot;,&amp;quot;name&amp;quot;:&amp;quot;FastEthernet5/0&amp;quot;,&amp;quot;parentId&amp;quot;:&amp;quot;i88e94c90-0fe2-4cf0-b418-9f1063c48f5a&amp;quot;,&amp;quot;inventoryResourceId&amp;quot;:&amp;quot;ff20e2db-a776-4028-a799-87f4edf2a087&amp;quot;,&amp;quot;originalId&amp;quot;:&amp;quot;i54eb92e5-2ded-46ba-b774-e49d347eee21&amp;quot;,&amp;quot;condition&amp;quot;:null,&amp;quot;problemCode&amp;quot;:null},&amp;quot;parentResource2&amp;quot;:{&amp;quot;id&amp;quot;:&amp;quot;i88e94c90-0fe2-4cf0-b418-9f1063c48f5a&amp;quot;,&amp;quot;name&amp;quot;:&amp;quot;Router1&amp;quot;,&amp;quot;parentId&amp;quot;:null,&amp;quot;inventoryResourceId&amp;quot;:&amp;quot;43ec0dde-d8b6-49d4-93b9-db7b147a04f1&amp;quot;,&amp;quot;originalId&amp;quot;:&amp;quot;i88e94c90-0fe2-4cf0-b418-9f1063c48f5a&amp;quot;,&amp;quot;condition&amp;quot;:null,&amp;quot;problemCode&amp;quot;:null},&amp;quot;bidirectional&amp;quot;:true,&amp;quot;connectionTypeName&amp;quot;:&amp;quot;Ethernet&amp;quot;,&amp;quot;condition&amp;quot;:&amp;quot;&amp;quot;,&amp;quot;problemCode&amp;quot;:null,&amp;quot;connections&amp;quot;:[]},{&amp;quot;id&amp;quot;:&amp;quot;i8b8e40e6-2d91-49a1-a6e0-84264fa69e34&amp;quot;,&amp;quot;isPortLink&amp;quot;:true,&amp;quot;resource1&amp;quot;:{&amp;quot;id&amp;quot;:&amp;quot;i15b51f3a-a561-4024-9f01-a8c8d53712e7&amp;quot;,&amp;quot;name&amp;quot;:&amp;quot;2/12&amp;quot;,&amp;quot;parentId&amp;quot;:&amp;quot;i583b18d9-6492-43e6-80bb-b0a0eb77f0d3&amp;quot;,&amp;quot;inventoryResourceId&amp;quot;:&amp;quot;5ce04128-cece-424a-92b8-5b064249d4ec&amp;quot;,&amp;quot;originalId&amp;quot;:&amp;quot;i15b51f3a-a561-4024-9f01-a8c8d53712e7&amp;quot;,&amp;quot;condition&amp;quot;:null,&amp;quot;problemCode&amp;quot;:null},&amp;quot;parentResource1&amp;quot;:{&amp;quot;id&amp;quot;:&amp;quot;i583b18d9-6492-43e6-80bb-b0a0eb77f0d3&amp;quot;,&amp;quot;name&amp;quot;:&amp;quot;STC1&amp;quot;,&amp;quot;parentId&amp;quot;:null,&amp;quot;inventoryResourceId&amp;quot;:&amp;quot;ab715126-4659-4e7a-a2ac-c5a689196b60&amp;quot;,&amp;quot;originalId&amp;quot;:&amp;quot;i583b18d9-6492-43e6-80bb-b0a0eb77f0d3&amp;quot;,&amp;quot;condition&amp;quot;:null,&amp;quot;problemCode&amp;quot;:null},&amp;quot;resource2&amp;quot;:{&amp;quot;id&amp;quot;:&amp;quot;i28e39bad-5bfd-4c93-8587-d13fe5c6a224&amp;quot;,&amp;quot;name&amp;quot;:&amp;quot;FastEthernet5/0&amp;quot;,&amp;quot;parentId&amp;quot;:&amp;quot;i59e4a3e6-8550-448a-b66e-b4c08dded753&amp;quot;,&amp;quot;inventoryResourceId&amp;quot;:&amp;quot;1ce78989-e998-4ed5-ae6d-475ee92796a9&amp;quot;,&amp;quot;originalId&amp;quot;:&amp;quot;i28e39bad-5bfd-4c93-8587-d13fe5c6a224&amp;quot;,&amp;quot;condition&amp;quot;:null,&amp;quot;problemCode&amp;quot;:null},&amp;quot;parentResource2&amp;quot;:{&amp;quot;id&amp;quot;:&amp;quot;i59e4a3e6-8550-448a-b66e-b4c08dded753&amp;quot;,&amp;quot;name&amp;quot;:&amp;quot;Router2&amp;quot;,&amp;quot;parentId&amp;quot;:null,&amp;quot;inventoryResourceId&amp;quot;:&amp;quot;f45dfdde-b8d8-4396-bbb0-e6ef43f747b5&amp;quot;,&amp;quot;originalId&amp;quot;:&amp;quot;i59e4a3e6-8550-448a-b66e-b4c08dded753&amp;quot;,&amp;quot;condition&amp;quot;:null,&amp;quot;problemCode&amp;quot;:null},&amp;quot;bidirectional&amp;quot;:true,&amp;quot;connectionTypeName&amp;quot;:&amp;quot;Ethernet&amp;quot;,&amp;quot;condition&amp;quot;:&amp;quot;&amp;quot;,&amp;quot;problemCode&amp;quot;:null,&amp;quot;connections&amp;quot;:[]}]}&lt;/responseRawText&gt;
+&lt;/structure&gt;
+</structuredData>
+                            <aliases>
+                                <item name="isEmpty">
+                                    <queryFormatString>.//isEmpty</queryFormatString>
+                                </item>
+                            </aliases>
+                            <duration>0.7</duration>
+                        </behavior>
+                    </emulation>
+                </item>
+                <item guid="ce527d6e-6faf-4e1d-9825-a36ca14e37fb" action="comment">
+                    <command>
+                        <body>Let&apos;s build a table for all the links</body>
+                    </command>
+                    <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                    <useFieldsInCommand>false</useFieldsInCommand>
+                </item>
+                <item guid="19bf62c1-6ef5-419a-af16-35a8e3818d44" action="for">
+                    <command>
+                        <body>{set itemNo 1} {$itemNo &lt;= $linkCount} {incr itemNo}</body>
+                    </command>
+                    <nestedSteps>
+                        <item guid="22087b2c-0e00-4cc7-a7b4-e398a6655841" action="if">
+                            <command>
+                                <body>$itemNo == 1</body>
+                            </command>
+                            <nestedSteps>
+                                <item guid="15529682-e0fe-4414-9d2f-0709c41e1dc0" action="then">
+                                    <nestedSteps>
+                                        <item guid="836423a0-f4f6-46e3-9afd-93e8d9bf4cf6" action="comment">
+                                            <command>
+                                                <body>set header info</body>
+                                            </command>
+                                            <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                                            <useFieldsInCommand>false</useFieldsInCommand>
+                                        </item>
+                                        <item guid="08b38c81-d950-47ea-ba21-0a10e8746602" action="write">
+                                            <command>
+                                                <body>linkId,endPointOne,resourceOne,endPointTwo,resourceTwo\\n</body>
+                                            </command>
+                                            <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                                        </item>
+                                    </nestedSteps>
+                                    <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                                    <useFieldsInCommand>false</useFieldsInCommand>
+                                </item>
+                            </nestedSteps>
+                            <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                            <useFieldsInCommand>false</useFieldsInCommand>
+                        </item>
+                        <item guid="9d959cde-6cab-4f4a-a564-f0d08d0f6465" action="comment">
+                            <command>
+                                <body>lets get interesting values</body>
+                            </command>
+                            <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                            <useFieldsInCommand>false</useFieldsInCommand>
+                        </item>
+                        <item guid="c8894d40-e906-4142-826f-56d5c628d70d" action="eval">
+                            <command>
+                                <body>set id [query topoLinks .//links/item\\[$itemNo\\]/id]</body>
+                            </command>
+                            <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                            <useFieldsInCommand>false</useFieldsInCommand>
+                        </item>
+                        <item guid="84d04150-4514-4368-89d3-e84970e8e619" action="eval">
+                            <command>
+                                <body>set endPointOne [query topoLinks .//item\\[$itemNo\\]/resource1/name]</body>
+                            </command>
+                            <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                            <useFieldsInCommand>false</useFieldsInCommand>
+                        </item>
+                        <item guid="2c45d655-58a8-45fe-8e44-b9a701aa9d03" action="eval">
+                            <command>
+                                <body>set resourceOne [query topoLinks .//item\\[$itemNo\\]/parentResource1/name]</body>
+                            </command>
+                            <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                            <useFieldsInCommand>false</useFieldsInCommand>
+                        </item>
+                        <item guid="bc0a3413-9fe3-47ac-9ffa-9743e30ca94c" action="eval">
+                            <command>
+                                <body>set endPointTwo [query topoLinks .//item\\[$itemNo\\]/resource2/name]</body>
+                            </command>
+                            <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                            <useFieldsInCommand>false</useFieldsInCommand>
+                        </item>
+                        <item guid="f0b8d182-6e6f-4d67-90f2-266602089252" action="eval">
+                            <command>
+                                <body>set resourceTwo [query topoLinks .//item\\[$itemNo\\]/parentResource2/name]</body>
+                            </command>
+                            <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                            <useFieldsInCommand>false</useFieldsInCommand>
+                        </item>
+                        <item guid="bc23f4a6-fba0-437f-baf6-b0e9158e95d5" action="write">
+                            <command>
+                                <body>$id,$endPointOne,$resourceOne,$endPointTwo,$resourceTwo\\n</body>
+                            </command>
+                            <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                        </item>
+                    </nestedSteps>
+                    <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                    <useFieldsInCommand>false</useFieldsInCommand>
+                </item>
+            </steps>
+            <author>Mike Barfield</author>
+            <multilineDescription>Getting the link info can be used to break/make links when using an L1 switch. Useful for negative testing. Requires a reservation ID and a token for authentication.
+
+Example return value:
+linkId,endPointOne,resourceOne,endPointTwo,resourceTwo
+ib5eada78-09f1-454d-a851-363dbea41d34,FastEthernet6/0,Router1,FastEthernet6/0,Router2
+icb5d9a7d-ae4d-45b5-ac37-84604fd3b1ad,2/11,STC1,FastEthernet5/0,Router1
+i8b8e40e6-2d91-49a1-a6e0-84264fa69e34,2/12,STC1,FastEthernet5/0,Router2</multilineDescription>
+            <arguments>
+                <item name="reservationId">
+                    <description>Valid reservation ID</description>
+                    <isMandatory>true</isMandatory>
+                </item>
+            </arguments>
+            <response>{&quot;linkId&quot;:&quot;value&quot;}</response>
+        </item>
+        <item name="getTopoLinkAction" isPublic="true">
+            <description>Get commands to break/restore links - requires L1</description>
+            <steps>
+                <item guid="b3a4ce6c-5f17-4019-8d4f-9ad8c695a7f5" action="GET" session="$session">
+                    <command>
+                        <body>/velocity/api/reservation/v9/reservation/$reservationId/state</body>
+                    </command>
+                    <postProcessing>
+                        <analysisRules>
+                            <item>
+                                <extractorInfo extractorType="query">
+                                    <extractorProperties type="com.fnfr.svt.mapping.execution.extractors.QueryDataExtractorPropertyGroup">
+                                        <query sub="true">count(.//elements/item\\[originalId = &apos;$linkId&apos;\\]/actions/item)</query>
+                                    </extractorProperties>
+                                </extractorInfo>
+                                <processorInfo ruleType="store">
+                                    <ruleProperties type="com.fnfr.svt.execution.builtin.processors.StoreProcessorPropertyGroup">
+                                        <storageLocation>actionCount</storageLocation>
+                                    </ruleProperties>
+                                </processorInfo>
+                            </item>
+                        </analysisRules>
+                        <storeResponseAt>linkActions</storeResponseAt>
+                    </postProcessing>
+                    <applicationProperties type="com.fnfr.svt.adapter.automation.tools.common.documents.TransferableDocumentObject" transferableToolId="com.fnfr.itest.applications.webservices.restful" transferableType="com.fnfr.itest.applications.webservices.properties.restful.RESTfulInvokeProperties" action="/velocity/api/reservation/v9/reservation/$reservationId/state" action.inherit="false"/>
+                    <emulation>
+                        <behavior>
+                            <response>{&quot;elements&quot;:[{&quot;originalId&quot;:&quot;ib5eada78-09f1-454d-a851-363dbea41d34&quot;,&quot;status&quot;:{&quot;code&quot;:&quot;ACTIVE&quot;,&quot;name&quot;:&quot;Connected&quot;,&quot;description&quot;:&quot;&quot;,&quot;transitional&quot;:false},&quot;properties&quot;:[],&quot;actions&quot;:[{&quot;code&quot;:&quot;BREAK_LINK&quot;,&quot;name&quot;:&quot;Break&quot;,&quot;description&quot;:&quot;Break connection between devices&quot;,&quot;isEnabled&quot;:true,&quot;type&quot;:&quot;HTTP_POST&quot;,&quot;url&quot;:&quot;https://10.108.36.207/velocity/api/reservation/v2/reservation/c47f9183-08db-4f22-95ad-a065bad4edec/link/ib5eada78-09f1-454d-a851-363dbea41d34/break&quot;,&quot;requestBody&quot;:null,&quot;isJob&quot;:true},{&quot;code&quot;:&quot;RESTORE_LINK&quot;,&quot;name&quot;:&quot;Restore&quot;,&quot;description&quot;:&quot;Restore connection between devices&quot;,&quot;isEnabled&quot;:false,&quot;type&quot;:&quot;HTTP_POST&quot;,&quot;url&quot;:&quot;https://10.108.36.207/velocity/api/reservation/v2/reservation/c47f9183-08db-4f22-95ad-a065bad4edec/link/ib5eada78-09f1-454d-a851-363dbea41d34/restore&quot;,&quot;requestBody&quot;:null,&quot;isJob&quot;:true}]},{&quot;originalId&quot;:&quot;i8dd38094-cd56-4992-ab5f-1cb94f9d2a44&quot;,&quot;status&quot;:{&quot;code&quot;:&quot;UNKNOWN&quot;,&quot;name&quot;:&quot;n/a&quot;,&quot;description&quot;:&quot;&quot;,&quot;transitional&quot;:false},&quot;properties&quot;:[],&quot;actions&quot;:[]},{&quot;originalId&quot;:&quot;i28e39bad-5bfd-4c93-8587-d13fe5c6a224&quot;,&quot;status&quot;:{&quot;code&quot;:&quot;UNKNOWN&quot;,&quot;name&quot;:&quot;n/a&quot;,&quot;description&quot;:&quot;&quot;,&quot;transitional&quot;:false},&quot;properties&quot;:[],&quot;actions&quot;:[]},{&quot;originalId&quot;:&quot;icb5d9a7d-ae4d-45b5-ac37-84604fd3b1ad&quot;,&quot;status&quot;:{&quot;code&quot;:&quot;ACTIVE&quot;,&quot;name&quot;:&quot;Connected&quot;,&quot;description&quot;:&quot;&quot;,&quot;transitional&quot;:false},&quot;properties&quot;:[],&quot;actions&quot;:[{&quot;code&quot;:&quot;BREAK_LINK&quot;,&quot;name&quot;:&quot;Break&quot;,&quot;description&quot;:&quot;Break connection between devices&quot;,&quot;isEnabled&quot;:true,&quot;type&quot;:&quot;HTTP_POST&quot;,&quot;url&quot;:&quot;https://10.108.36.207/velocity/api/reservation/v2/reservation/c47f9183-08db-4f22-95ad-a065bad4edec/link/icb5d9a7d-ae4d-45b5-ac37-84604fd3b1ad/break&quot;,&quot;requestBody&quot;:null,&quot;isJob&quot;:true},{&quot;code&quot;:&quot;RESTORE_LINK&quot;,&quot;name&quot;:&quot;Restore&quot;,&quot;description&quot;:&quot;Restore connection between devices&quot;,&quot;isEnabled&quot;:false,&quot;type&quot;:&quot;HTTP_POST&quot;,&quot;url&quot;:&quot;https://10.108.36.207/velocity/api/reservation/v2/reservation/c47f9183-08db-4f22-95ad-a065bad4edec/link/icb5d9a7d-ae4d-45b5-ac37-84604fd3b1ad/restore&quot;,&quot;requestBody&quot;:null,&quot;isJob&quot;:true}]},{&quot;originalId&quot;:&quot;i54eb92e5-2ded-46ba-b774-e49d347eee21&quot;,&quot;status&quot;:{&quot;code&quot;:&quot;UNKNOWN&quot;,&quot;name&quot;:&quot;n/a&quot;,&quot;description&quot;:&quot;&quot;,&quot;transitional&quot;:false},&quot;properties&quot;:[],&quot;actions&quot;:[]},{&quot;originalId&quot;:&quot;ic3671279-51c0-4b17-ae03-161d7afb13ad--i0a071427-dfed-4078-a414-3c0e2deee3cb&quot;,&quot;status&quot;:{&quot;code&quot;:&quot;ACTIVE&quot;,&quot;name&quot;:&quot;Online&quot;,&quot;description&quot;:&quot;&quot;,&quot;transitional&quot;:false},&quot;properties&quot;:[],&quot;actions&quot;:[]},{&quot;originalId&quot;:&quot;i161877e7-df30-492a-ad70-e11499be8fa1&quot;,&quot;status&quot;:{&quot;code&quot;:&quot;UNKNOWN&quot;,&quot;name&quot;:&quot;n/a&quot;,&quot;description&quot;:&quot;&quot;,&quot;transitional&quot;:false},&quot;properties&quot;:[],&quot;actions&quot;:[]},{&quot;originalId&quot;:&quot;i8b8e40e6-2d91-49a1-a6e0-84264fa69e34&quot;,&quot;status&quot;:{&quot;code&quot;:&quot;ACTIVE&quot;,&quot;name&quot;:&quot;Connected&quot;,&quot;description&quot;:&quot;&quot;,&quot;transitional&quot;:false},&quot;properties&quot;:[],&quot;actions&quot;:[{&quot;code&quot;:&quot;BREAK_LINK&quot;,&quot;name&quot;:&quot;Break&quot;,&quot;description&quot;:&quot;Break connection between devices&quot;,&quot;isEnabled&quot;:true,&quot;type&quot;:&quot;HTTP_POST&quot;,&quot;url&quot;:&quot;https://10.108.36.207/velocity/api/reservation/v2/reservation/c47f9183-08db-4f22-95ad-a065bad4edec/link/i8b8e40e6-2d91-49a1-a6e0-84264fa69e34/break&quot;,&quot;requestBody&quot;:null,&quot;isJob&quot;:true},{&quot;code&quot;:&quot;RESTORE_LINK&quot;,&quot;name&quot;:&quot;Restore&quot;,&quot;description&quot;:&quot;Restore connection between devices&quot;,&quot;isEnabled&quot;:false,&quot;type&quot;:&quot;HTTP_POST&quot;,&quot;url&quot;:&quot;https://10.108.36.207/velocity/api/reservation/v2/reservation/c47f9183-08db-4f22-95ad-a065bad4edec/link/i8b8e40e6-2d91-49a1-a6e0-84264fa69e34/restore&quot;,&quot;requestBody&quot;:null,&quot;isJob&quot;:true}]},{&quot;originalId&quot;:&quot;i15b51f3a-a561-4024-9f01-a8c8d53712e7&quot;,&quot;status&quot;:{&quot;code&quot;:&quot;UNKNOWN&quot;,&quot;name&quot;:&quot;n/a&quot;,&quot;description&quot;:&quot;&quot;,&quot;transitional&quot;:false},&quot;properties&quot;:[],&quot;actions&quot;:[]},{&quot;originalId&quot;:&quot;i583b18d9-6492-43e6-80bb-b0a0eb77f0d3&quot;,&quot;status&quot;:{&quot;code&quot;:&quot;ACTIVE&quot;,&quot;name&quot;:&quot;Online&quot;,&quot;description&quot;:&quot;&quot;,&quot;transitional&quot;:false},&quot;properties&quot;:[],&quot;actions&quot;:[{&quot;code&quot;:&quot;TERM_web&quot;,&quot;name&quot;:&quot;web&quot;,&quot;description&quot;:&quot;Open web&quot;,&quot;isEnabled&quot;:true,&quot;type&quot;:&quot;OPEN_URL&quot;,&quot;url&quot;:&quot;http://10.108.32.17&quot;,&quot;requestBody&quot;:null,&quot;isJob&quot;:false}]},{&quot;originalId&quot;:&quot;i9323ec37-8a48-45d4-ab60-44a406df6159&quot;,&quot;status&quot;:{&quot;code&quot;:&quot;UNKNOWN&quot;,&quot;name&quot;:&quot;n/a&quot;,&quot;description&quot;:&quot;&quot;,&quot;transitional&quot;:false},&quot;properties&quot;:[],&quot;actions&quot;:[]},{&quot;originalId&quot;:&quot;i8684ee1e-ce53-4f24-9c50-d4e70ea30419&quot;,&quot;status&quot;:{&quot;code&quot;:&quot;UNKNOWN&quot;,&quot;name&quot;:&quot;n/a&quot;,&quot;description&quot;:&quot;&quot;,&quot;transitional&quot;:false},&quot;properties&quot;:[],&quot;actions&quot;:[]},{&quot;originalId&quot;:&quot;i59e4a3e6-8550-448a-b66e-b4c08dded753&quot;,&quot;status&quot;:{&quot;code&quot;:&quot;ACTIVE&quot;,&quot;name&quot;:&quot;Online&quot;,&quot;description&quot;:&quot;&quot;,&quot;transitional&quot;:false},&quot;properties&quot;:[],&quot;actions&quot;:[{&quot;code&quot;:&quot;TERM_telnet&quot;,&quot;name&quot;:&quot;telnet&quot;,&quot;description&quot;:&quot;Open telnet&quot;,&quot;isEnabled&quot;:true,&quot;type&quot;:&quot;OPEN_URL&quot;,&quot;url&quot;:&quot;https://10.108.36.207/terminal/#?hostname=10.108.32.92&amp;protocol=telnet&amp;port=23&quot;,&quot;requestBody&quot;:null,&quot;isJob&quot;:false}]},{&quot;originalId&quot;:&quot;ic3d8ee93-5197-4fa5-b4cd-7fee662ec760&quot;,&quot;status&quot;:{&quot;code&quot;:&quot;UNKNOWN&quot;,&quot;name&quot;:&quot;n/a&quot;,&quot;description&quot;:&quot;&quot;,&quot;transitional&quot;:false},&quot;properties&quot;:[],&quot;actions&quot;:[]},{&quot;originalId&quot;:&quot;i88e94c90-0fe2-4cf0-b418-9f1063c48f5a&quot;,&quot;status&quot;:{&quot;code&quot;:&quot;ACTIVE&quot;,&quot;name&quot;:&quot;Online&quot;,&quot;description&quot;:&quot;&quot;,&quot;transitional&quot;:false},&quot;properties&quot;:[],&quot;actions&quot;:[{&quot;code&quot;:&quot;TERM_telnet&quot;,&quot;name&quot;:&quot;telnet&quot;,&quot;description&quot;:&quot;Open telnet&quot;,&quot;isEnabled&quot;:true,&quot;type&quot;:&quot;OPEN_URL&quot;,&quot;url&quot;:&quot;https://10.108.36.207/terminal/#?hostname=10.108.32.91&amp;protocol=telnet&amp;port=23&quot;,&quot;requestBody&quot;:null,&quot;isJob&quot;:false}]}],&quot;isReady&quot;:true}</response>
+                            <responseType>text</responseType>
+                            <structuredData>
+&lt;structure xmlns:map=&quot;http://www.fnfr.com/svt/mapping&quot;&gt;
+    &lt;statusCode value=&quot;200&quot;/&gt;
+    &lt;requestHTTPHeaders map:nodetype=&quot;token&quot;&gt;
+        &lt;Content_Type map:nodetype=&quot;token&quot;&gt;application/json&lt;/Content_Type&gt;
+        &lt;X_Auth_Token map:nodetype=&quot;token&quot;&gt;eyJwYWNrZXQiOiAie1wiZXhwaXJhdGlvblwiOiAxNTI2NDkyODI0LCBcInVzZXJfbmFtZVwiOiBcIk1pa2UgQmFyZmllbGRcIiwgXCJkb21haW5cIjogXCJsZGFwXCIsIFwic3RhcnRfdGltZVwiOiAxNTI2NDA1MjI0LCBcImlkXCI6IFwibWJhcmZpZWxkXCJ9IiwgInNpZ25hdHVyZSI6ICI0ZDc2ZWU0Zjk5MTAyMWEyYmRhNzY4NmQxNGIxYzEyNzJjOGVmMzBmOTI0NWNjOTFkZDQyOWViZTQ3YWM0MmI1ZjRiZGE1MjYxZDY3YTExMTI3NTg3MGQxZTU5NmRjNjliZTM0OTc1NzdmMjJlZDhmNjYzNTVjYzE3NzllZTAzNGI5ODVjOWYzOTJlMjIyZGYxMjQzNjE2MTdmMWQxODNkZmRkNzdkNjVhOGRhNjQ3ODhlNjQ2ZjQwMjA0NDlhZjViNmZhZmEzNzEzYTFmNjQ1NTIxNzBkYmNjOWJlNGFlZmFlODg5OWYzNWI5ODg4NGUzNGYzZjMxZjgyYTE5YmMyMzUwYzcyMjdiMTU3MjQ3ZGRiNjc3NTFhOWI1NzMyYmMyYmRjNjdiZDFmOWEwNTZjYTMzYWZjYmVkOTRjMWY0YTQ2MDUzNTIzZjNiNWEwYjdlNjA2NTE2ZjYxNTcyYTg1MTJmM2U4ZjcxNWUxZjM3N2QwZWVhZjkyNjFiMmNjMjU3MTc3OWRhMjIxZDEyMWU5MjMzNTc5ZWQ4MGZiYjA3YjA5NTQ5ODhmNjhmMzRkZjdkMzgzMmIxMzMzODUzZDg3ZDM5N2JjZDhjYWIxMDJiN2QxNzg3ODM2NTdiN2E3MDIzMjkwODFhMDFjNmM1M2NhM2U3MTdhYzUwNTEwZWExMCJ9&lt;/X_Auth_Token&gt;
+    &lt;/requestHTTPHeaders&gt;
+    &lt;requestRawText map:nodetype=&quot;token&quot;/&gt;
+    &lt;responseHTTPHeaders map:nodetype=&quot;token&quot;&gt;
+        &lt;Server map:nodetype=&quot;token&quot;&gt;nginx/1.10.3 (Ubuntu)&lt;/Server&gt;
+        &lt;Cache_Control map:nodetype=&quot;token&quot;&gt;no-cache, no-store, must-revalidate&lt;/Cache_Control&gt;
+        &lt;Cache_Control map:nodetype=&quot;token&quot;&gt;no-cache&lt;/Cache_Control&gt;
+        &lt;Connection map:nodetype=&quot;token&quot;&gt;keep-alive&lt;/Connection&gt;
+        &lt;Expires map:nodetype=&quot;token&quot;&gt;0&lt;/Expires&gt;
+        &lt;Pragma map:nodetype=&quot;token&quot;&gt;no-cache&lt;/Pragma&gt;
+        &lt;Content_Length map:nodetype=&quot;token&quot;&gt;5015&lt;/Content_Length&gt;
+        &lt;Date map:nodetype=&quot;token&quot;&gt;Tue, 15 May 2018 17:47:09 GMT&lt;/Date&gt;
+        &lt;Content_Type map:nodetype=&quot;token&quot;&gt;application/json&lt;/Content_Type&gt;
+        &lt;X_Powered_By map:nodetype=&quot;token&quot;&gt;Undertow/1&lt;/X_Powered_By&gt;
+    &lt;/responseHTTPHeaders&gt;
+    &lt;responseRawText map:nodetype=&quot;token&quot;&gt;{&amp;quot;elements&amp;quot;:[{&amp;quot;originalId&amp;quot;:&amp;quot;ib5eada78-09f1-454d-a851-363dbea41d34&amp;quot;,&amp;quot;status&amp;quot;:{&amp;quot;code&amp;quot;:&amp;quot;ACTIVE&amp;quot;,&amp;quot;name&amp;quot;:&amp;quot;Connected&amp;quot;,&amp;quot;description&amp;quot;:&amp;quot;&amp;quot;,&amp;quot;transitional&amp;quot;:false},&amp;quot;properties&amp;quot;:[],&amp;quot;actions&amp;quot;:[{&amp;quot;code&amp;quot;:&amp;quot;BREAK_LINK&amp;quot;,&amp;quot;name&amp;quot;:&amp;quot;Break&amp;quot;,&amp;quot;description&amp;quot;:&amp;quot;Break connection between devices&amp;quot;,&amp;quot;isEnabled&amp;quot;:true,&amp;quot;type&amp;quot;:&amp;quot;HTTP_POST&amp;quot;,&amp;quot;url&amp;quot;:&amp;quot;https://10.108.36.207/velocity/api/reservation/v2/reservation/c47f9183-08db-4f22-95ad-a065bad4edec/link/ib5eada78-09f1-454d-a851-363dbea41d34/break&amp;quot;,&amp;quot;requestBody&amp;quot;:null,&amp;quot;isJob&amp;quot;:true},{&amp;quot;code&amp;quot;:&amp;quot;RESTORE_LINK&amp;quot;,&amp;quot;name&amp;quot;:&amp;quot;Restore&amp;quot;,&amp;quot;description&amp;quot;:&amp;quot;Restore connection between devices&amp;quot;,&amp;quot;isEnabled&amp;quot;:false,&amp;quot;type&amp;quot;:&amp;quot;HTTP_POST&amp;quot;,&amp;quot;url&amp;quot;:&amp;quot;https://10.108.36.207/velocity/api/reservation/v2/reservation/c47f9183-08db-4f22-95ad-a065bad4edec/link/ib5eada78-09f1-454d-a851-363dbea41d34/restore&amp;quot;,&amp;quot;requestBody&amp;quot;:null,&amp;quot;isJob&amp;quot;:true}]},{&amp;quot;originalId&amp;quot;:&amp;quot;i8dd38094-cd56-4992-ab5f-1cb94f9d2a44&amp;quot;,&amp;quot;status&amp;quot;:{&amp;quot;code&amp;quot;:&amp;quot;UNKNOWN&amp;quot;,&amp;quot;name&amp;quot;:&amp;quot;n/a&amp;quot;,&amp;quot;description&amp;quot;:&amp;quot;&amp;quot;,&amp;quot;transitional&amp;quot;:false},&amp;quot;properties&amp;quot;:[],&amp;quot;actions&amp;quot;:[]},{&amp;quot;originalId&amp;quot;:&amp;quot;i28e39bad-5bfd-4c93-8587-d13fe5c6a224&amp;quot;,&amp;quot;status&amp;quot;:{&amp;quot;code&amp;quot;:&amp;quot;UNKNOWN&amp;quot;,&amp;quot;name&amp;quot;:&amp;quot;n/a&amp;quot;,&amp;quot;description&amp;quot;:&amp;quot;&amp;quot;,&amp;quot;transitional&amp;quot;:false},&amp;quot;properties&amp;quot;:[],&amp;quot;actions&amp;quot;:[]},{&amp;quot;originalId&amp;quot;:&amp;quot;icb5d9a7d-ae4d-45b5-ac37-84604fd3b1ad&amp;quot;,&amp;quot;status&amp;quot;:{&amp;quot;code&amp;quot;:&amp;quot;ACTIVE&amp;quot;,&amp;quot;name&amp;quot;:&amp;quot;Connected&amp;quot;,&amp;quot;description&amp;quot;:&amp;quot;&amp;quot;,&amp;quot;transitional&amp;quot;:false},&amp;quot;properties&amp;quot;:[],&amp;quot;actions&amp;quot;:[{&amp;quot;code&amp;quot;:&amp;quot;BREAK_LINK&amp;quot;,&amp;quot;name&amp;quot;:&amp;quot;Break&amp;quot;,&amp;quot;description&amp;quot;:&amp;quot;Break connection between devices&amp;quot;,&amp;quot;isEnabled&amp;quot;:true,&amp;quot;type&amp;quot;:&amp;quot;HTTP_POST&amp;quot;,&amp;quot;url&amp;quot;:&amp;quot;https://10.108.36.207/velocity/api/reservation/v2/reservation/c47f9183-08db-4f22-95ad-a065bad4edec/link/icb5d9a7d-ae4d-45b5-ac37-84604fd3b1ad/break&amp;quot;,&amp;quot;requestBody&amp;quot;:null,&amp;quot;isJob&amp;quot;:true},{&amp;quot;code&amp;quot;:&amp;quot;RESTORE_LINK&amp;quot;,&amp;quot;name&amp;quot;:&amp;quot;Restore&amp;quot;,&amp;quot;description&amp;quot;:&amp;quot;Restore connection between devices&amp;quot;,&amp;quot;isEnabled&amp;quot;:false,&amp;quot;type&amp;quot;:&amp;quot;HTTP_POST&amp;quot;,&amp;quot;url&amp;quot;:&amp;quot;https://10.108.36.207/velocity/api/reservation/v2/reservation/c47f9183-08db-4f22-95ad-a065bad4edec/link/icb5d9a7d-ae4d-45b5-ac37-84604fd3b1ad/restore&amp;quot;,&amp;quot;requestBody&amp;quot;:null,&amp;quot;isJob&amp;quot;:true}]},{&amp;quot;originalId&amp;quot;:&amp;quot;i54eb92e5-2ded-46ba-b774-e49d347eee21&amp;quot;,&amp;quot;status&amp;quot;:{&amp;quot;code&amp;quot;:&amp;quot;UNKNOWN&amp;quot;,&amp;quot;name&amp;quot;:&amp;quot;n/a&amp;quot;,&amp;quot;description&amp;quot;:&amp;quot;&amp;quot;,&amp;quot;transitional&amp;quot;:false},&amp;quot;properties&amp;quot;:[],&amp;quot;actions&amp;quot;:[]},{&amp;quot;originalId&amp;quot;:&amp;quot;ic3671279-51c0-4b17-ae03-161d7afb13ad--i0a071427-dfed-4078-a414-3c0e2deee3cb&amp;quot;,&amp;quot;status&amp;quot;:{&amp;quot;code&amp;quot;:&amp;quot;ACTIVE&amp;quot;,&amp;quot;name&amp;quot;:&amp;quot;Online&amp;quot;,&amp;quot;description&amp;quot;:&amp;quot;&amp;quot;,&amp;quot;transitional&amp;quot;:false},&amp;quot;properties&amp;quot;:[],&amp;quot;actions&amp;quot;:[]},{&amp;quot;originalId&amp;quot;:&amp;quot;i161877e7-df30-492a-ad70-e11499be8fa1&amp;quot;,&amp;quot;status&amp;quot;:{&amp;quot;code&amp;quot;:&amp;quot;UNKNOWN&amp;quot;,&amp;quot;name&amp;quot;:&amp;quot;n/a&amp;quot;,&amp;quot;description&amp;quot;:&amp;quot;&amp;quot;,&amp;quot;transitional&amp;quot;:false},&amp;quot;properties&amp;quot;:[],&amp;quot;actions&amp;quot;:[]},{&amp;quot;originalId&amp;quot;:&amp;quot;i8b8e40e6-2d91-49a1-a6e0-84264fa69e34&amp;quot;,&amp;quot;status&amp;quot;:{&amp;quot;code&amp;quot;:&amp;quot;ACTIVE&amp;quot;,&amp;quot;name&amp;quot;:&amp;quot;Connected&amp;quot;,&amp;quot;description&amp;quot;:&amp;quot;&amp;quot;,&amp;quot;transitional&amp;quot;:false},&amp;quot;properties&amp;quot;:[],&amp;quot;actions&amp;quot;:[{&amp;quot;code&amp;quot;:&amp;quot;BREAK_LINK&amp;quot;,&amp;quot;name&amp;quot;:&amp;quot;Break&amp;quot;,&amp;quot;description&amp;quot;:&amp;quot;Break connection between devices&amp;quot;,&amp;quot;isEnabled&amp;quot;:true,&amp;quot;type&amp;quot;:&amp;quot;HTTP_POST&amp;quot;,&amp;quot;url&amp;quot;:&amp;quot;https://10.108.36.207/velocity/api/reservation/v2/reservation/c47f9183-08db-4f22-95ad-a065bad4edec/link/i8b8e40e6-2d91-49a1-a6e0-84264fa69e34/break&amp;quot;,&amp;quot;requestBody&amp;quot;:null,&amp;quot;isJob&amp;quot;:true},{&amp;quot;code&amp;quot;:&amp;quot;RESTORE_LINK&amp;quot;,&amp;quot;name&amp;quot;:&amp;quot;Restore&amp;quot;,&amp;quot;description&amp;quot;:&amp;quot;Restore connection between devices&amp;quot;,&amp;quot;isEnabled&amp;quot;:false,&amp;quot;type&amp;quot;:&amp;quot;HTTP_POST&amp;quot;,&amp;quot;url&amp;quot;:&amp;quot;https://10.108.36.207/velocity/api/reservation/v2/reservation/c47f9183-08db-4f22-95ad-a065bad4edec/link/i8b8e40e6-2d91-49a1-a6e0-84264fa69e34/restore&amp;quot;,&amp;quot;requestBody&amp;quot;:null,&amp;quot;isJob&amp;quot;:true}]},{&amp;quot;originalId&amp;quot;:&amp;quot;i15b51f3a-a561-4024-9f01-a8c8d53712e7&amp;quot;,&amp;quot;status&amp;quot;:{&amp;quot;code&amp;quot;:&amp;quot;UNKNOWN&amp;quot;,&amp;quot;name&amp;quot;:&amp;quot;n/a&amp;quot;,&amp;quot;description&amp;quot;:&amp;quot;&amp;quot;,&amp;quot;transitional&amp;quot;:false},&amp;quot;properties&amp;quot;:[],&amp;quot;actions&amp;quot;:[]},{&amp;quot;originalId&amp;quot;:&amp;quot;i583b18d9-6492-43e6-80bb-b0a0eb77f0d3&amp;quot;,&amp;quot;status&amp;quot;:{&amp;quot;code&amp;quot;:&amp;quot;ACTIVE&amp;quot;,&amp;quot;name&amp;quot;:&amp;quot;Online&amp;quot;,&amp;quot;description&amp;quot;:&amp;quot;&amp;quot;,&amp;quot;transitional&amp;quot;:false},&amp;quot;properties&amp;quot;:[],&amp;quot;actions&amp;quot;:[{&amp;quot;code&amp;quot;:&amp;quot;TERM_web&amp;quot;,&amp;quot;name&amp;quot;:&amp;quot;web&amp;quot;,&amp;quot;description&amp;quot;:&amp;quot;Open web&amp;quot;,&amp;quot;isEnabled&amp;quot;:true,&amp;quot;type&amp;quot;:&amp;quot;OPEN_URL&amp;quot;,&amp;quot;url&amp;quot;:&amp;quot;http://10.108.32.17&amp;quot;,&amp;quot;requestBody&amp;quot;:null,&amp;quot;isJob&amp;quot;:false}]},{&amp;quot;originalId&amp;quot;:&amp;quot;i9323ec37-8a48-45d4-ab60-44a406df6159&amp;quot;,&amp;quot;status&amp;quot;:{&amp;quot;code&amp;quot;:&amp;quot;UNKNOWN&amp;quot;,&amp;quot;name&amp;quot;:&amp;quot;n/a&amp;quot;,&amp;quot;description&amp;quot;:&amp;quot;&amp;quot;,&amp;quot;transitional&amp;quot;:false},&amp;quot;properties&amp;quot;:[],&amp;quot;actions&amp;quot;:[]},{&amp;quot;originalId&amp;quot;:&amp;quot;i8684ee1e-ce53-4f24-9c50-d4e70ea30419&amp;quot;,&amp;quot;status&amp;quot;:{&amp;quot;code&amp;quot;:&amp;quot;UNKNOWN&amp;quot;,&amp;quot;name&amp;quot;:&amp;quot;n/a&amp;quot;,&amp;quot;description&amp;quot;:&amp;quot;&amp;quot;,&amp;quot;transitional&amp;quot;:false},&amp;quot;properties&amp;quot;:[],&amp;quot;actions&amp;quot;:[]},{&amp;quot;originalId&amp;quot;:&amp;quot;i59e4a3e6-8550-448a-b66e-b4c08dded753&amp;quot;,&amp;quot;status&amp;quot;:{&amp;quot;code&amp;quot;:&amp;quot;ACTIVE&amp;quot;,&amp;quot;name&amp;quot;:&amp;quot;Online&amp;quot;,&amp;quot;description&amp;quot;:&amp;quot;&amp;quot;,&amp;quot;transitional&amp;quot;:false},&amp;quot;properties&amp;quot;:[],&amp;quot;actions&amp;quot;:[{&amp;quot;code&amp;quot;:&amp;quot;TERM_telnet&amp;quot;,&amp;quot;name&amp;quot;:&amp;quot;telnet&amp;quot;,&amp;quot;description&amp;quot;:&amp;quot;Open telnet&amp;quot;,&amp;quot;isEnabled&amp;quot;:true,&amp;quot;type&amp;quot;:&amp;quot;OPEN_URL&amp;quot;,&amp;quot;url&amp;quot;:&amp;quot;https://10.108.36.207/terminal/#?hostname=10.108.32.92&amp;amp;protocol=telnet&amp;amp;port=23&amp;quot;,&amp;quot;requestBody&amp;quot;:null,&amp;quot;isJob&amp;quot;:false}]},{&amp;quot;originalId&amp;quot;:&amp;quot;ic3d8ee93-5197-4fa5-b4cd-7fee662ec760&amp;quot;,&amp;quot;status&amp;quot;:{&amp;quot;code&amp;quot;:&amp;quot;UNKNOWN&amp;quot;,&amp;quot;name&amp;quot;:&amp;quot;n/a&amp;quot;,&amp;quot;description&amp;quot;:&amp;quot;&amp;quot;,&amp;quot;transitional&amp;quot;:false},&amp;quot;properties&amp;quot;:[],&amp;quot;actions&amp;quot;:[]},{&amp;quot;originalId&amp;quot;:&amp;quot;i88e94c90-0fe2-4cf0-b418-9f1063c48f5a&amp;quot;,&amp;quot;status&amp;quot;:{&amp;quot;code&amp;quot;:&amp;quot;ACTIVE&amp;quot;,&amp;quot;name&amp;quot;:&amp;quot;Online&amp;quot;,&amp;quot;description&amp;quot;:&amp;quot;&amp;quot;,&amp;quot;transitional&amp;quot;:false},&amp;quot;properties&amp;quot;:[],&amp;quot;actions&amp;quot;:[{&amp;quot;code&amp;quot;:&amp;quot;TERM_telnet&amp;quot;,&amp;quot;name&amp;quot;:&amp;quot;telnet&amp;quot;,&amp;quot;description&amp;quot;:&amp;quot;Open telnet&amp;quot;,&amp;quot;isEnabled&amp;quot;:true,&amp;quot;type&amp;quot;:&amp;quot;OPEN_URL&amp;quot;,&amp;quot;url&amp;quot;:&amp;quot;https://10.108.36.207/terminal/#?hostname=10.108.32.91&amp;amp;protocol=telnet&amp;amp;port=23&amp;quot;,&amp;quot;requestBody&amp;quot;:null,&amp;quot;isJob&amp;quot;:false}]}],&amp;quot;isReady&amp;quot;:true}&lt;/responseRawText&gt;
+&lt;/structure&gt;
+</structuredData>
+                            <aliases>
+                                <item name="isEmpty">
+                                    <queryFormatString>.//isEmpty</queryFormatString>
+                                </item>
+                            </aliases>
+                            <duration>0.7</duration>
+                        </behavior>
+                    </emulation>
+                </item>
+                <item guid="a7d44074-db6f-4b1b-9776-dfba8f7b3749" action="comment">
+                    <command>
+                        <body>Return the link status</body>
+                    </command>
+                    <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                    <useFieldsInCommand>false</useFieldsInCommand>
+                </item>
+                <item guid="69741d42-625f-49ac-a5e0-9e422906b052" action="write">
+                    <command>
+                        <body>Link Status: [query linkActions &quot;.//elements/item\\[originalId = &apos;$linkId&apos;\\]/status/code&quot;]\\n\\n</body>
+                    </command>
+                    <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                </item>
+                <item guid="6df01db6-3f9e-4e0d-9728-078e1b70ac47" action="comment">
+                    <command>
+                        <body>Get the URLs for each of the actions</body>
+                    </command>
+                    <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                    <useFieldsInCommand>false</useFieldsInCommand>
+                </item>
+                <item guid="90e7ce30-bc2b-4fa5-895d-c2ca44071d36" action="for">
+                    <command>
+                        <body>{set actionNo 1} {$actionNo &lt;= $actionCount} {incr actionNo}</body>
+                    </command>
+                    <nestedSteps>
+                        <item guid="f2144eda-ed41-4b63-93eb-bf4382d1b48a" action="comment">
+                            <command>
+                                <body>Make a table of available actions</body>
+                            </command>
+                            <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                            <useFieldsInCommand>false</useFieldsInCommand>
+                        </item>
+                        <item guid="55a58efe-26c6-4128-981d-6d55a742ee98" action="if">
+                            <command>
+                                <body>$actionNo == 1</body>
+                            </command>
+                            <nestedSteps>
+                                <item guid="5a607626-b0ff-4cf3-be7c-7c7e03a29ac8" action="then">
+                                    <nestedSteps>
+                                        <item guid="1838585b-3475-41b6-a1bb-695b70e0510b" action="comment">
+                                            <command>
+                                                <body>create table header</body>
+                                            </command>
+                                            <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                                            <useFieldsInCommand>false</useFieldsInCommand>
+                                        </item>
+                                        <item guid="f83d592e-9f80-410d-bd59-62ca4bb3b532" action="write">
+                                            <command>
+                                                <body>actionName,actionType,actionUrl\\n</body>
+                                            </command>
+                                            <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                                        </item>
+                                    </nestedSteps>
+                                    <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                                    <useFieldsInCommand>false</useFieldsInCommand>
+                                </item>
+                            </nestedSteps>
+                            <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                            <useFieldsInCommand>false</useFieldsInCommand>
+                        </item>
+                        <item guid="249a5c52-03e8-4f05-9e80-7654d80f0645" action="eval">
+                            <command>
+                                <body>set name [query linkActions &quot;.//elements/item\\[originalId = &apos;$linkId&apos;\\]/actions/item\\[$actionNo\\]/name&quot;]</body>
+                            </command>
+                            <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                            <useFieldsInCommand>false</useFieldsInCommand>
+                        </item>
+                        <item guid="5dc77454-0382-463c-87c1-f486e6dd7c4e" action="eval">
+                            <command>
+                                <body>set type [query linkActions &quot;.//elements/item\\[originalId = &apos;$linkId&apos;\\]/actions/item\\[$actionNo\\]/type&quot;]</body>
+                            </command>
+                            <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                            <useFieldsInCommand>false</useFieldsInCommand>
+                        </item>
+                        <item guid="2b178106-d654-46f7-b4e8-53e38d5a952d" action="eval">
+                            <command>
+                                <body>set url [query linkActions &quot;.//elements/item\\[originalId = &apos;$linkId&apos;\\]/actions/item\\[$actionNo\\]/url&quot;]</body>
+                            </command>
+                            <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                            <useFieldsInCommand>false</useFieldsInCommand>
+                        </item>
+                        <item guid="6e21e47f-c354-4aab-bda8-296502e36b84" action="write">
+                            <command>
+                                <body>$name,$type,$url\\n</body>
+                            </command>
+                            <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                        </item>
+                    </nestedSteps>
+                    <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                    <useFieldsInCommand>false</useFieldsInCommand>
+                </item>
+            </steps>
+            <author>Mike Barfield</author>
+            <multilineDescription>This procedure will return the actions required to break/restore links using Velocity API. This will return a nice table that is responsed mapped. Use link info retrieved by getTopoLinkInfo.
+
+Example return values:
+Link Status: ACTIVE
+
+actionName,actionType,actionUrl
+Break,HTTP_POST,https://10.108.36.207/velocity/api/reservation/v2/reservation/c1cc9976-5e0d-4d06-b0bb-e75f2097bbc0/link/i3a578913-e61a-4051-97f1-31186fe8260e/break
+Restore,HTTP_POST,https://10.108.36.207/velocity/api/reservation/v2/reservation/c1cc9976-5e0d-4d06-b0bb-e75f2097bbc0/link/i3a578913-e61a-4051-97f1-31186fe8260e/restore
+</multilineDescription>
+            <arguments>
+                <item name="reservationId">
+                    <description>Valid reservation ID</description>
+                    <isMandatory>true</isMandatory>
+                </item>
+                <item name="linkId">
+                    <description>Valid link ID</description>
+                    <isMandatory>true</isMandatory>
+                </item>
+            </arguments>
+        </item>
+        <item name="postAction" isPublic="true" isVBlock="true">
+            <description>Post action to delete/restore link</description>
+            <steps>
+                <item guid="4d212ad0-6ee6-43c1-be20-4647ecc354ed" action="POST" session="$session">
+                    <command>
+                        <body>$url</body>
+                    </command>
+                    <postProcessing>
+                        <analysisRules>
+                            <item>
+                                <extractorInfo extractorType="query">
+                                    <extractorProperties type="com.fnfr.svt.mapping.execution.extractors.QueryDataExtractorPropertyGroup">
+                                        <query>mapped/Json/jobId</query>
+                                    </extractorProperties>
+                                </extractorInfo>
+                                <processorInfo ruleType="store">
+                                    <ruleProperties type="com.fnfr.svt.execution.builtin.processors.StoreProcessorPropertyGroup">
+                                        <storageLocation>jobId</storageLocation>
+                                        <query>jobId</query>
+                                    </ruleProperties>
+                                </processorInfo>
+                            </item>
+                        </analysisRules>
+                        <storeResponseAt>retVal</storeResponseAt>
+                        <storeResponseText>true</storeResponseText>
+                    </postProcessing>
+                    <applicationProperties type="com.fnfr.svt.adapter.automation.tools.common.documents.TransferableDocumentObject" transferableToolId="com.fnfr.itest.applications.webservices.restful" transferableType="com.fnfr.itest.applications.webservices.properties.restful.RESTfulInvokeProperties" action="$url" action.inherit="false"/>
+                    <emulation>
+                        <behavior>
+                            <response>{&quot;jobId&quot;:&quot;28d4f99a-7f9c-4b54-94ca-5d567d8ca832&quot;}</response>
+                            <responseType>text</responseType>
+                            <structuredData>
+&lt;structure xmlns:map=&quot;http://www.fnfr.com/svt/mapping&quot;&gt;
+    &lt;statusCode value=&quot;202&quot;/&gt;
+    &lt;requestHTTPHeaders map:nodetype=&quot;token&quot;&gt;
+        &lt;Content_Type map:nodetype=&quot;token&quot;&gt;application/json&lt;/Content_Type&gt;
+        &lt;X_Auth_Token map:nodetype=&quot;token&quot;&gt;eyJwYWNrZXQiOiAie1wiZXhwaXJhdGlvblwiOiAxNTI2NDc3MDUwLCBcInVzZXJfbmFtZVwiOiBcIk1pa2UgQmFyZmllbGRcIiwgXCJkb21haW5cIjogXCJsZGFwXCIsIFwic3RhcnRfdGltZVwiOiAxNTI2Mzg5NDUwLCBcImlkXCI6IFwibWJhcmZpZWxkXCJ9IiwgInNpZ25hdHVyZSI6ICI0OTE5ZGM2NmQ5ODg2ZjY4NDcyODZmNjFjYTNlZTc5NjY2ODIyY2E0MWM5YmQ5MjM1NWYwZGM0MzA2MTk3OTJhYmI1MTE0ZTdhYWUyN2YzNzkyOWUyNzAxNjUzM2QzMGFlOGIxOWI2MzM2NDA3MjM0MzA2NzhlNGE4YTkyOTRkOWNmNGM2M2JjMGI4ZDU3YjE2N2U5NGFkNGIzNjcyYWYzODM5Y2NlOTRlZGU2ZWU1NjMyZWVjNTU4ZDg1MWNiNzFjNDFmODhmNGY4NzhjODAzNjRiZDhlOTI1YWY2YzJmYTcwMWE4NDkzOGZiYzkyNTg1NWFmZWFjOTRhY2M5N2IxMzU1YjllOGU4ZTU0ZmEwN2JlNjQ2Mzg2NDk0MDM4NTY4YTg3MjFmOTk2MDgzMGI2NDNkYTA2ZDIwMWMxMGQ0M2ZmNjA3NjJlY2E2NjczNTA0MzEyNmExMWRjZTc1MjU3NmE4MjE0NjgwM2IzM2NmMjdiYmY1ZWIyNWYxMDg5MzFkNjdmOTdkMjQzZTM1MjUyZDQ3ZTdmNTk5N2M4YTczY2FiMDUyNWIwYTcyOTQ5NjRmNjAzNTRjYWEzYTFhY2EzNDUyMTg2YmZkZTJjYzYxZDVjMzMzNWE2YzY5MDU2NjY3M2FmMWE0MjMwMGRiZTEzNTdhYzMxNjA2YTk4YjI4YyJ9&lt;/X_Auth_Token&gt;
+    &lt;/requestHTTPHeaders&gt;
+    &lt;requestRawText map:nodetype=&quot;token&quot;/&gt;
+    &lt;responseHTTPHeaders map:nodetype=&quot;token&quot;&gt;
+        &lt;Server map:nodetype=&quot;token&quot;&gt;nginx/1.10.3 (Ubuntu)&lt;/Server&gt;
+        &lt;Cache_Control map:nodetype=&quot;token&quot;&gt;no-cache, no-store, must-revalidate&lt;/Cache_Control&gt;
+        &lt;Connection map:nodetype=&quot;token&quot;&gt;keep-alive&lt;/Connection&gt;
+        &lt;Expires map:nodetype=&quot;token&quot;&gt;0&lt;/Expires&gt;
+        &lt;Pragma map:nodetype=&quot;token&quot;&gt;no-cache&lt;/Pragma&gt;
+        &lt;Content_Length map:nodetype=&quot;token&quot;&gt;48&lt;/Content_Length&gt;
+        &lt;Date map:nodetype=&quot;token&quot;&gt;Tue, 15 May 2018 13:24:16 GMT&lt;/Date&gt;
+        &lt;Content_Type map:nodetype=&quot;token&quot;&gt;application/json&lt;/Content_Type&gt;
+        &lt;X_Powered_By map:nodetype=&quot;token&quot;&gt;Undertow/1&lt;/X_Powered_By&gt;
+        &lt;Location map:nodetype=&quot;token&quot;&gt;https://10.108.36.207/velocity/api/job/v1/job/28d4f99a-7f9c-4b54-94ca-5d567d8ca832&lt;/Location&gt;
+    &lt;/responseHTTPHeaders&gt;
+    &lt;responseRawText map:nodetype=&quot;token&quot;&gt;{&amp;quot;jobId&amp;quot;:&amp;quot;28d4f99a-7f9c-4b54-94ca-5d567d8ca832&amp;quot;}&lt;/responseRawText&gt;
+&lt;/structure&gt;
+</structuredData>
+                            <aliases>
+                                <item name="isEmpty">
+                                    <queryFormatString>.//isEmpty</queryFormatString>
+                                </item>
+                            </aliases>
+                            <duration>0.9</duration>
+                        </behavior>
+                    </emulation>
+                </item>
+                <item guid="3d5db5e0-659f-4133-987c-8217ed1ace1e" action="comment">
+                    <command>
+                        <body>Check if the job finishes in a timily manner and if it doesn&apos;t delete the job</body>
+                    </command>
+                    <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                    <useFieldsInCommand>false</useFieldsInCommand>
+                </item>
+                <item guid="9c1785c2-f151-4f8f-8eb7-4be63cc81680" action="eval">
+                    <command>
+                        <body>set deleteJob 1</body>
+                    </command>
+                    <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                    <useFieldsInCommand>false</useFieldsInCommand>
+                </item>
+                <item guid="01964959-8cd3-401c-8d15-cc2cf9574adb" action="GET" session="$session">
+                    <command>
+                        <body>/velocity/api/job/v1/job/$jobId</body>
+                    </command>
+                    <postProcessing>
+                        <analysisRules>
+                            <item>
+                                <extractorInfo extractorType="query">
+                                    <extractorProperties type="com.fnfr.svt.mapping.execution.extractors.QueryDataExtractorPropertyGroup">
+                                        <query>mapped/Json/status</query>
+                                    </extractorProperties>
+                                </extractorInfo>
+                                <processorInfo ruleType="assert">
+                                    <ruleProperties type="com.fnfr.svt.execution.builtin.processors.AssertionPropertyGroup">
+                                        <expression>$value == &quot;SUCCESS&quot;</expression>
+                                        <actionsWhenTrue>
+                                            <item actionId="DeclareExecutionIssue">
+                                                <actionProperties type="com.fnfr.svt.execution.builtin.actions.ExecutionIssuePropertyGroup" severity="OK">
+                                                    <message>Job: $jobId status; Waiting for SUCCESS, actual state: $value</message>
+                                                </actionProperties>
+                                            </item>
+                                            <item actionId="PassTestIfNotAlreadyFailed">
+                                                <actionProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                                            </item>
+                                            <item actionId="Eval">
+                                                <actionProperties type="com.fnfr.svt.execution.builtin.actions.EvalActionPropertyGroup">
+                                                    <statement>set deleteJob 0</statement>
+                                                </actionProperties>
+                                            </item>
+                                        </actionsWhenTrue>
+                                        <actionsWhenFalse>
+                                            <item actionId="DeclareExecutionIssue">
+                                                <actionProperties type="com.fnfr.svt.execution.builtin.actions.ExecutionIssuePropertyGroup" severity="Information">
+                                                    <message>Job: $jobId status; Waiting for SUCCESS, actual state: $value</message>
+                                                </actionProperties>
+                                            </item>
+                                            <item actionId="RepeatStep">
+                                                <actionProperties type="com.fnfr.svt.execution.builtin.actions.RepeatStepPropertyGroup" maxRepeatCount="$retries" maxRepeatCount.sub="true" delayBetweenRepeats="5.0"/>
+                                            </item>
+                                        </actionsWhenFalse>
+                                    </ruleProperties>
+                                </processorInfo>
+                            </item>
+                        </analysisRules>
+                    </postProcessing>
+                    <applicationProperties type="com.fnfr.svt.adapter.automation.tools.common.documents.TransferableDocumentObject" transferableToolId="com.fnfr.itest.applications.webservices.restful" transferableType="com.fnfr.itest.applications.webservices.properties.restful.RESTfulInvokeProperties" action="/velocity/api/job/v1/job/$jobId" action.inherit="false"/>
+                </item>
+                <item guid="8bc1426a-7c38-43e8-8a25-ae499a91ee37" action="if">
+                    <command>
+                        <body>$deleteJob == 1</body>
+                    </command>
+                    <nestedSteps>
+                        <item guid="f88d18aa-a02d-42d8-b53c-55898335f761" action="then">
+                            <nestedSteps>
+                                <item guid="7a91f87f-8e32-4dfd-9d79-61bc042bb164" action="DELETE" session="$session">
+                                    <command>
+                                        <body>/velocity/api/job/v1/job/$jobId</body>
+                                    </command>
+                                    <applicationProperties type="com.fnfr.svt.adapter.automation.tools.common.documents.TransferableDocumentObject" transferableToolId="com.fnfr.itest.applications.webservices.restful" transferableType="com.fnfr.itest.applications.webservices.properties.restful.RESTfulInvokeProperties" action="/velocity/api/job/v1/job/$jobId" action.inherit="false"/>
+                                </item>
+                            </nestedSteps>
+                            <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                            <useFieldsInCommand>false</useFieldsInCommand>
+                        </item>
+                        <item guid="4a560545-811e-4040-a408-42f59646c276" action="else">
+                            <nestedSteps>
+                                <item guid="6c5fe495-9452-46e6-8da3-f69cba4f95a0" action="comment">
+                                    <command>
+                                        <body>Insert steps here for when the expression evaluates to false</body>
+                                    </command>
+                                    <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                                    <useFieldsInCommand>false</useFieldsInCommand>
+                                </item>
+                            </nestedSteps>
+                            <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                            <useFieldsInCommand>false</useFieldsInCommand>
+                        </item>
+                    </nestedSteps>
+                    <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                    <useFieldsInCommand>false</useFieldsInCommand>
+                </item>
+                <item guid="1d4a3fcc-7c4d-4420-b439-e184c0076a5e" action="eval">
+                    <command>
+                        <body>puts $deleteJob</body>
+                    </command>
+                    <postProcessing>
+                        <analysisRules>
+                            <item>
+                                <extractorInfo extractorType="query">
+                                    <extractorProperties type="com.fnfr.svt.mapping.execution.extractors.QueryDataExtractorPropertyGroup">
+                                        <query>group1()</query>
+                                    </extractorProperties>
+                                </extractorInfo>
+                                <processorInfo ruleType="store">
+                                    <ruleProperties type="com.fnfr.svt.execution.builtin.processors.StoreProcessorPropertyGroup">
+                                        <storageLocation>deleteJobState</storageLocation>
+                                        <query>deleteJobState</query>
+                                    </ruleProperties>
+                                </processorInfo>
+                            </item>
+                        </analysisRules>
+                    </postProcessing>
+                    <applicationProperties type="com.fnfr.svt.documents.EmptyPropertyGroup"/>
+                    <useFieldsInCommand>false</useFieldsInCommand>
+                </item>
+            </steps>
+            <author>Mike Barfield</author>
+            <multilineDescription>This can be used to make or restore links using Velocity. This is handy to simulate cable cuts.
+
+This will check that the job completes in a timly manner and if not it will terminate the job.
+
+Example return value:
+{
+  &quot;jobId&quot;: &quot;c3fd5df8-2c2b-465d-a578-dd2f5e2f66a4&quot;,
+  &quot;deleteJobState&quot;: &quot;0&quot;
+}</multilineDescription>
+            <arguments>
+                <item name="url">
+                    <description>Valid action url</description>
+                    <isMandatory>true</isMandatory>
+                </item>
+                <item name="retries">
+                    <description>This is the max number of retries before failing (5 sec delay/retry)</description>
+                    <defaultValue>24</defaultValue>
+                </item>
+            </arguments>
+            <response>{&quot;jobId&quot;:&quot;value&quot;,&quot;deleteJobState&quot;:&quot;value&quot;}</response>
+        </item>
+    </procedures>
+</testCase>


### PR DESCRIPTION
This gives testers a method to work with Velocity as part of their testing. I kept velocity as a device project because you can utilize the Velocity REST interface like any other device and there are many ways to utilize it.